### PR TITLE
Exclude global builders from EquationFactory pickle state.

### DIFF
--- a/diffpy/srfit/equation/builder.py
+++ b/diffpy/srfit/equation/builder.py
@@ -352,9 +352,10 @@ class EquationFactory(object):
         builders = dict(self.builders)
         # Do not store global builders
         for key, builder in _builders.iteritems():
-            if state.get(key) is builder:
+            if builders.get(key) is builder:
                 del builders[key]
         state['builders'] = builders
+        return state
 
     def __setstate__(self, state):
         self.newargs = state.get('newargs', set())

--- a/diffpy/srfit/equation/builder.py
+++ b/diffpy/srfit/equation/builder.py
@@ -345,6 +345,24 @@ class EquationFactory(object):
 
         return args
 
+    def __getstate__(self):
+        """ Provided to not store, and leak, module-level state. """
+        state = {'newargs': set(self.newargs),
+                 'equations': set(self.equations)}
+        builders = dict(self.builders)
+        # Do not store global builders
+        for key, builder in _builders.iteritems():
+            if state.get(key) is builder:
+                del builders[key]
+        state['builders'] = builders
+
+    def __setstate__(self, state):
+        self.newargs = state.get('newargs', set())
+        self.equations = state.get('equations', set())
+        self.builders = state.get('builders', {})
+        self.builders.update(_builders)
+
+
 # End class EquationFactory
 
 class BaseBuilder(object):


### PR DESCRIPTION
This fixes a memory leak that occurs when pickling and unpicklng any object that stores an `EquationFactory`. It should be tested with some real-world cases to assure it is doing the right thing.