### PR TITLE
fix recipe pickling for Python 3

### DIFF
--- a/src/diffpy/srfit/equation/builder.py
+++ b/src/diffpy/srfit/equation/builder.py
@@ -642,16 +642,14 @@ def __wrapSrFitOperators():
     instances in the module namespace.
     """
     opmod = literals.operators
-    for opname in dir(opmod):
-        opclass = getattr(opmod, opname)
-        skip = (not inspect.isclass(opclass) or
-                not issubclass(opclass, opmod.Operator) or
-                inspect.isabstract(opclass) or
-                opclass is opmod.CustomOperator or
-                opclass is opmod.UFuncOperator)
-        if skip:
-            continue
-        # here opclass is a desired Operator class
+    excluded_types = set((opmod.CustomOperator, opmod.UFuncOperator))
+    # check if opmod member should be wrapped as OperatorBuilder
+    is_exported_type = lambda cls : (
+        inspect.isclass(cls) and issubclass(cls, opmod.Operator) and
+        not inspect.isabstract(cls) and
+        not cls in excluded_types)
+    # create OperatorBuilder objects
+    for nm, opclass in inspect.getmembers(opmod, is_exported_type):
         op = opclass()
         _builders[op.name] = OperatorBuilder(op.name, op)
     return

--- a/src/diffpy/srfit/equation/builder.py
+++ b/src/diffpy/srfit/equation/builder.py
@@ -651,6 +651,7 @@ def __wrapSrFitOperators():
     # create OperatorBuilder objects
     for nm, opclass in inspect.getmembers(opmod, is_exported_type):
         op = opclass()
+        assert op.name, "Unnamed Operator should never appear here."
         _builders[op.name] = OperatorBuilder(op.name, op)
     return
 __wrapSrFitOperators()

--- a/src/diffpy/srfit/equation/equationmod.py
+++ b/src/diffpy/srfit/equation/equationmod.py
@@ -107,13 +107,15 @@ class Equation(Operator):
         return self.name
 
 
-    @property
-    def operation(self):
-        """The bound __call__ method of this Equation object.
+    def operation(self, *args, **kw):
+        """Evaluate this Equation object.
 
-        This can be called as is to perform the operation.
+        Same as the __call__ method.  This method is used via
+        the Operator interface.
+
+        Return the result of __call__(*args, **kw).
         """
-        return self.__call__
+        return self.__call__(*args, **kw)
 
 
     def _getArgs(self):
@@ -172,6 +174,7 @@ class Equation(Operator):
 
         return
 
+
     def __call__(self, *args, **kw):
         """Call the equation.
 
@@ -181,7 +184,6 @@ class Equation(Operator):
 
         Raises
         ValueError when a passed argument cannot be found
-
         """
         # Process args
         for idx, val in enumerate(args):

--- a/src/diffpy/srfit/equation/equationmod.py
+++ b/src/diffpy/srfit/equation/equationmod.py
@@ -77,6 +77,10 @@ class Equation(Operator):
     value   --  Property for 'getValue'.
     """
 
+    # define abstract attributes from the Operator base.
+    nin = None
+    nout = 1
+
     def __init__(self, name = None, root = None):
         """Initialize.
 
@@ -91,16 +95,16 @@ class Equation(Operator):
         if name is None and root is not None:
             name = "eq_%s"%root.name
         Literal.__init__(self, name)
-        self.symbol = name
-        self.nin = None
-        self.nout = 1
-
         self.root = None
         self.argdict = OrderedDict()
         if root is not None:
             self.setRoot(root)
-
         return
+
+
+    @property
+    def symbol(self):
+        return self.name
 
 
     @property

--- a/src/diffpy/srfit/equation/literals/__init__.py
+++ b/src/diffpy/srfit/equation/literals/__init__.py
@@ -25,17 +25,20 @@ is that described by the Visitor pattern
 (http://en.wikipedia.org/wiki/Visitor_pattern).
 """
 
-__all__ = ["Argument", "Operator", "AdditionOperator", "SubtractionOperator",
+__all__ = ["Argument", "Operator", "BinaryOperator", "CustomOperator",
+           "AdditionOperator", "SubtractionOperator",
            "MultiplicationOperator", "DivisionOperator", "ExponentiationOperator",
            "RemainderOperator", "NegationOperator", "ConvolutionOperator",
            "SumOperator", "UFuncOperator", "ListOperator", "SetOperator",
-           "ArrayOperator", "PolyvalOperator"]
+           "ArrayOperator", "PolyvalOperator", "makeOperator"]
 
 
 # Import the operators
 
 from diffpy.srfit.equation.literals.argument import Argument
 from diffpy.srfit.equation.literals.operators import Operator
+from diffpy.srfit.equation.literals.operators import BinaryOperator
+from diffpy.srfit.equation.literals.operators import CustomOperator
 from diffpy.srfit.equation.literals.operators import AdditionOperator
 from diffpy.srfit.equation.literals.operators import SubtractionOperator
 from diffpy.srfit.equation.literals.operators import MultiplicationOperator
@@ -50,5 +53,6 @@ from diffpy.srfit.equation.literals.operators import ListOperator
 from diffpy.srfit.equation.literals.operators import SetOperator
 from diffpy.srfit.equation.literals.operators import ArrayOperator
 from diffpy.srfit.equation.literals.operators import PolyvalOperator
+from diffpy.srfit.equation.literals.operators import makeOperator
 
 # End of file

--- a/src/diffpy/srfit/equation/literals/__init__.py
+++ b/src/diffpy/srfit/equation/literals/__init__.py
@@ -29,8 +29,8 @@ __all__ = ["Argument", "Operator", "BinaryOperator", "CustomOperator",
            "AdditionOperator", "SubtractionOperator",
            "MultiplicationOperator", "DivisionOperator", "ExponentiationOperator",
            "RemainderOperator", "NegationOperator", "ConvolutionOperator",
-           "SumOperator", "UFuncOperator", "ListOperator", "SetOperator",
-           "ArrayOperator", "PolyvalOperator", "makeOperator"]
+           "SumOperator", "UFuncOperator", "ArrayOperator", "PolyvalOperator",
+           "makeOperator"]
 
 
 # Import the operators
@@ -49,8 +49,6 @@ from diffpy.srfit.equation.literals.operators import NegationOperator
 from diffpy.srfit.equation.literals.operators import ConvolutionOperator
 from diffpy.srfit.equation.literals.operators import UFuncOperator
 from diffpy.srfit.equation.literals.operators import SumOperator
-from diffpy.srfit.equation.literals.operators import ListOperator
-from diffpy.srfit.equation.literals.operators import SetOperator
 from diffpy.srfit.equation.literals.operators import ArrayOperator
 from diffpy.srfit.equation.literals.operators import PolyvalOperator
 from diffpy.srfit.equation.literals.operators import makeOperator

--- a/src/diffpy/srfit/equation/literals/abcs.py
+++ b/src/diffpy/srfit/equation/literals/abcs.py
@@ -21,10 +21,8 @@ __all__ = ["LiteralABC", "ArgumentABC", "OperatorABC"]
 from abc import ABCMeta, abstractmethod, abstractproperty
 
 
-class LiteralABC(object):
+class LiteralABC(metaclass=ABCMeta):
     """Abstract Base Class for Literal. See Literal for usage."""
-
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def identify(self, visitor): pass
@@ -36,6 +34,7 @@ class LiteralABC(object):
 
 # End class LiteralABC
 
+
 class ArgumentABC(LiteralABC):
     """Abstract Base Class for Argument. See Argument for usage."""
 
@@ -46,6 +45,7 @@ class ArgumentABC(LiteralABC):
     value = abstractproperty(None, None)
 
 # End class ArgumentABC
+
 
 class OperatorABC(LiteralABC):
     """Abstract Base Class for Operator. See Operator for usage."""

--- a/src/diffpy/srfit/equation/literals/literal.py
+++ b/src/diffpy/srfit/equation/literals/literal.py
@@ -39,10 +39,11 @@ class Literal(Observable,LiteralABC):
     name = None
     _value = None
 
-    def __init__(self, name = None):
+    def __init__(self, name=None):
         """Initialization."""
         Observable.__init__(self)
-        self.name = name
+        if name is not None:
+            self.name = name
         return
 
     def getValue(self):

--- a/src/diffpy/srfit/equation/literals/operators.py
+++ b/src/diffpy/srfit/equation/literals/operators.py
@@ -45,6 +45,9 @@ class Operator(Literal, OperatorABC):
     information alone.
 
     Attributes
+
+    FIXME
+
     args    --  List of Literal arguments, set with 'addLiteral'
     name    --  A name for this operator. e.g. "add" or "sin"
     nin     --  Number of inputs (<1 means this is variable)
@@ -53,26 +56,18 @@ class Operator(Literal, OperatorABC):
     symbol  --  The symbolic representation. e.g. "+" or "sin".
     _value  --  The value of the Operator.
     value   --  Property for 'getValue'.
-
     """
 
     args = None
-    nin = None
-    nout = None
-    operation = None
-    symbol = None
     _value = None
 
-    def __init__(self, name = None, symbol = None, operation = None, nin = 2,
-            nout = 1):
+
+    def __init__(self, name=None):
         """Initialization."""
         Literal.__init__(self, name)
-        self.symbol = symbol
-        self.nin = nin
-        self.nout = nout
         self.args = []
-        self.operation = operation
         return
+
 
     def identify(self, visitor):
         """Identify self to a visitor."""
@@ -114,86 +109,97 @@ class Operator(Literal, OperatorABC):
                 self._loopCheck(l)
         return
 
+
+class BinaryOperator(Operator):
+
+    nin = 2
+    nout = 1
+    pass
+
+
+class CustomOperator(Operator):
+
+    # non-abstract user-defined operator
+    nin = None
+    nout = None
+    operation = None
+    symbol = None
+
+
+def makeOperator(name, symbol, operation, nin, nout):
+    op = CustomOperator(name=name)
+    op.symbol = symbol
+    op.operation = operation
+    op.nin = nin
+    op.nout = nout
+    return op
+
 # Some specified operators
 
 
-class AdditionOperator(Operator):
+class AdditionOperator(BinaryOperator):
     """Addition operator."""
 
-    def __init__(self):
-        """Initialization."""
-        Operator.__init__(self)
-        self.name = "add"
-        self.symbol = "+"
-        self.operation = numpy.add
-        return
+    name = "add"
+    symbol = "+"
+    operation = staticmethod(numpy.add)
+    pass
 
-class SubtractionOperator(Operator):
+
+class SubtractionOperator(BinaryOperator):
     """Subtraction operator."""
 
-    def __init__(self):
-        """Initialization."""
-        Operator.__init__(self)
-        self.name = "subtract"
-        self.symbol = "-"
-        self.operation = numpy.subtract
-        return
+    name = "subtract"
+    symbol = "-"
+    operation = staticmethod(numpy.subtract)
+    pass
 
-class MultiplicationOperator(Operator):
+
+class MultiplicationOperator(BinaryOperator):
     """Multiplication operator."""
 
-    def __init__(self):
-        """Initialization."""
-        Operator.__init__(self)
-        self.name = "multiply"
-        self.symbol = "*"
-        self.operation = numpy.multiply
-        return
+    name = "multiply"
+    symbol = "*"
+    operation = staticmethod(numpy.multiply)
+    pass
 
-class DivisionOperator(Operator):
+
+class DivisionOperator(BinaryOperator):
     """Division operator."""
 
-    def __init__(self):
-        """Initialization."""
-        Operator.__init__(self)
-        self.name = "divide"
-        self.symbol = "/"
-        self.operation = numpy.divide
-        return
+    name = "divide"
+    symbol = "/"
+    operation = staticmethod(numpy.divide)
+    pass
 
-class ExponentiationOperator(Operator):
+
+class ExponentiationOperator(BinaryOperator):
     """Exponentiation operator."""
 
-    def __init__(self):
-        """Initialization."""
-        Operator.__init__(self)
-        self.name = "power"
-        self.symbol = "**"
-        self.operation = numpy.power
-        return
+    name = "power"
+    symbol = "**"
+    operation = staticmethod(numpy.power)
+    pass
 
-class RemainderOperator(Operator):
+
+class RemainderOperator(BinaryOperator):
     """Remainder operator."""
 
-    def __init__(self):
-        """Initialization."""
-        Operator.__init__(self)
-        self.name = "mod"
-        self.symbol = "%"
-        self.operation = numpy.mod
-        return
+    name = "mod"
+    symbol = "%"
+    operation = staticmethod(numpy.mod)
+    pass
+
 
 class NegationOperator(Operator):
     """Negation operator."""
 
-    def __init__(self):
-        """Initialization."""
-        Operator.__init__(self)
-        self.name = "negative"
-        self.symbol = "-"
-        self.nin = 1
-        self.operation = numpy.negative
-        return
+    name = "negative"
+    symbol = "-"
+    nin = 1
+    nout = 1
+    operation = staticmethod(numpy.negative)
+    pass
 
 
 def _conv(v1, v2):
@@ -219,7 +225,8 @@ def _conv(v1, v2):
 
     return c
 
-class ConvolutionOperator(Operator):
+
+class ConvolutionOperator(BinaryOperator):
     """Convolve two signals.
 
     This convolves two signals such that centroid of the first array is not
@@ -229,108 +236,98 @@ class ConvolutionOperator(Operator):
 
     Note that this is only possible when the signals are computed over the same
     range.
-
     """
 
-    def __init__(self):
-        """Initialization."""
-        Operator.__init__(self)
-        self.name = "convolve"
-        self.symbol = "convolve"
-        self.operation = _conv
-        return
+    name = "convolve"
+    symbol = "convolve"
+    operation = staticmethod(_conv)
+    pass
+
 
 class SumOperator(Operator):
     """numpy.sum operator."""
 
-    def __init__(self):
-        """Initialization."""
-        Operator.__init__(self)
-        self.name = "sum"
-        self.symbol = "sum"
-        self.nin = 1
-        self.nout = 1
-        self.operation = numpy.sum
-        return
+    name = "sum"
+    symbol = "sum"
+    nin = 1
+    nout = 1
+    operation = staticmethod(numpy.sum)
+
 
 class UFuncOperator(Operator):
     """A operator wrapper around a numpy ufunc.
 
     The name and symbol attributes are set equal to the ufunc.__name__
     attribute. nin and nout are also taken from the ufunc.
-
     """
+
+    symbol = None
+    nin = None
+    nout = None
+    operation = None
 
     def __init__(self, op):
         """Initialization.
 
         Arguments
-        op  --  A numpy ufunc
 
+        op  --  A numpy ufunc
         """
-        Operator.__init__(self)
-        self.name = op.__name__
+        Operator.__init__(self, name=op.__name__)
         self.symbol = op.__name__
         self.nin = op.nin
         self.nout = op.nout
         self.operation = op
         return
 
-def _makeList(*args):
-    return args
 
 class ListOperator(Operator):
     """Operator that will take parameters and turn them into a list."""
 
-    def __init__(self):
-        """Initialization."""
-        Operator.__init__(self)
-        self.name = "list"
-        self.symbol = "list"
-        self.nin = -1
-        self.operation = _makeList
-        return
+    name = "list"
+    symbol = "list"
+    nin = -1
+    nout = 1
 
-def _makeSet(*args):
-    return set(args)
+    @staticmethod
+    def operation(*args):
+        """Convert arguments into a list."""
+        return args
+
 
 class SetOperator(Operator):
     """Operator that will take parameters and turn them into a set."""
 
-    def __init__(self):
-        """Initialization."""
-        Operator.__init__(self)
-        self.name = "set"
-        self.symbol = "set"
-        self.nin = -1
-        self.operation = _makeSet
-        return
+    name = "set"
+    symbol = "set"
+    nin = -1
+    nout = 1
 
-def _makeArray(*args):
-    return numpy.array(args)
+    @staticmethod
+    def operation(*args):
+        """Convert arguments into a set."""
+        return set(args)
+
 
 class ArrayOperator(Operator):
     """Operator that will take parameters and turn them into an array."""
 
-    def __init__(self):
-        """Initialization."""
-        Operator.__init__(self)
-        self.name = "array"
-        self.symbol = "array"
-        self.nin = -1
-        self.operation = _makeArray
-        return
+    name = "array"
+    symbol = "array"
+    nin = -1
+    nout = 1
 
-class PolyvalOperator(Operator):
+    @staticmethod
+    def operation(*args):
+        return numpy.array(args)
+
+
+class PolyvalOperator(BinaryOperator):
     """Operator for numpy polyval."""
 
-    def __init__(self):
-        """Initialization."""
-        Operator.__init__(self)
-        self.name = "polyval"
-        self.symbol = "polyval"
-        self.nin = 2
-        self.operation = numpy.polyval
-        return
+    name = "polyval"
+    symbol = "polyval"
+    operation = staticmethod(numpy.polyval)
+    pass
 
 # End of file

--- a/src/diffpy/srfit/equation/literals/operators.py
+++ b/src/diffpy/srfit/equation/literals/operators.py
@@ -50,7 +50,7 @@ class Operator(Literal, OperatorABC):
 
     args    --  List of Literal arguments, set with 'addLiteral'
     name    --  A name for this operator. e.g. "add" or "sin"
-    nin     --  Number of inputs (<1 means this is variable)
+    nin     --  Number of inputs (-1 means this is variable)
     nout    --  Number of outputs
     operation   --  Function that performs the operation. e.g. numpy.add.
     symbol  --  The symbolic representation. e.g. "+" or "sin".

--- a/src/diffpy/srfit/equation/literals/operators.py
+++ b/src/diffpy/srfit/equation/literals/operators.py
@@ -110,6 +110,13 @@ class Operator(Literal, OperatorABC):
         return
 
 
+class UnaryOperator(Operator):
+
+    nin = 1
+    nout = 1
+    pass
+
+
 class BinaryOperator(Operator):
 
     nin = 2
@@ -191,13 +198,11 @@ class RemainderOperator(BinaryOperator):
     pass
 
 
-class NegationOperator(Operator):
+class NegationOperator(UnaryOperator):
     """Negation operator."""
 
     name = "negative"
     symbol = "-"
-    nin = 1
-    nout = 1
     operation = staticmethod(numpy.negative)
     pass
 
@@ -244,13 +249,11 @@ class ConvolutionOperator(BinaryOperator):
     pass
 
 
-class SumOperator(Operator):
+class SumOperator(UnaryOperator):
     """numpy.sum operator."""
 
     name = "sum"
     symbol = "sum"
-    nin = 1
-    nout = 1
     operation = staticmethod(numpy.sum)
 
 

--- a/src/diffpy/srfit/equation/literals/operators.py
+++ b/src/diffpy/srfit/equation/literals/operators.py
@@ -38,32 +38,56 @@ from diffpy.srfit.equation.literals.literal import Literal
 
 
 class Operator(Literal, OperatorABC):
-    """Class for holding a general operator.
+    """Abstract class for specifying a general operator.
 
-    This holds a general operator and records its function, arguments, name and
-    symbol.  The visitors should be able to process any Operator with this
-    information alone.
+    This class provides several methods that are common to a derived
+    classes for concrete concrete operations.
+
+    Class Attributes
+    ----------------
+    nin : int, abstract
+        Number of input arguments for the operator.  Any number of
+        arguments is allowed when -1.  This attribute must be defined
+        in a derived class.
+    nout : int, abstract
+        Number of outputs returned by the `operation`.  This attribute
+        must be defined in a derived class.
+    operation : callable, abstract
+        Function that performs the operation, e.g., `numpy.add`.
+        This must be defined in a derived class.
+    symbol : str, abstract
+        The symbolic representation for the operator such as
+        "+" or "sin".  This attribute must be defined in a derived
+        class.
 
     Attributes
-
-    FIXME
-
-    args    --  List of Literal arguments, set with 'addLiteral'
-    name    --  A name for this operator. e.g. "add" or "sin"
-    nin     --  Number of inputs (-1 means this is variable)
-    nout    --  Number of outputs
-    operation   --  Function that performs the operation. e.g. numpy.add.
-    symbol  --  The symbolic representation. e.g. "+" or "sin".
-    _value  --  The value of the Operator.
-    value   --  Property for 'getValue'.
+    ----------
+    args : list
+        The list of `Literal` arguments.  Read-only, use the
+        `addLiteral` method to change its content.
     """
 
+    # Private Attributes
+    # ------------------
+    # _value : float, numpy.ndarray or None
+    #     The last value of the operator or None.
+
+
+    # We must declare the abstract `args` here.
     args = None
+    # default for the value
     _value = None
 
 
     def __init__(self, name=None):
-        """Initialization."""
+        """Initialize the operator object with the specified name.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name for the operator object.  When not specified,
+            use the class attribute `name`.
+        """
         Literal.__init__(self, name)
         self.args = []
         return

--- a/src/diffpy/srfit/equation/literals/operators.py
+++ b/src/diffpy/srfit/equation/literals/operators.py
@@ -135,6 +135,13 @@ class Operator(Literal, OperatorABC):
 
 
 class UnaryOperator(Operator):
+    """
+    Abstract class for an unary operator with one input and one result.
+
+    This base class defines the `nin` and `nout` attributes.  The derived
+    concrete operator must provide the remaining abstract attributes
+    of the `Operator` class.
+    """
 
     nin = 1
     nout = 1
@@ -142,6 +149,13 @@ class UnaryOperator(Operator):
 
 
 class BinaryOperator(Operator):
+    """
+    Abstract class for a binary operator with two inputs and one result.
+
+    This base class defines the `nin` and `nout` attributes.  The derived
+    concrete operator must define the remaining abstract attributes
+    of the `Operator` class.
+    """
 
     nin = 2
     nout = 1
@@ -149,15 +163,43 @@ class BinaryOperator(Operator):
 
 
 class CustomOperator(Operator):
+    """
+    Concrete class for a user-defined Operator.
 
-    # non-abstract user-defined operator
+    Use the `makeOperator` factory function to create an instance.
+    """
+
+    # declare all abstract attributes from the Operator base.
     nin = None
     nout = None
     operation = None
     symbol = None
+    pass
 
 
 def makeOperator(name, symbol, operation, nin, nout):
+    """Return a new custom operator object.
+
+    Parameters
+    ----------
+    name : str
+        Name of the custom operator object.
+    symbol : str
+        The symbolic representation for the operator such as
+        "+" or "sin".
+    operation : callable
+        Function that performs the operation, e.g., `numpy.add`.
+    nin : int
+        Number of input arguments for the operator.  Any number of
+        arguments is allowed when -1.
+    nout : in
+        Number of outputs returned by the `operation`.
+
+    Returns
+    -------
+    CustomOperator
+        The new custom operator object.
+    """
     op = CustomOperator(name=name)
     op.symbol = symbol
     op.operation = operation

--- a/src/diffpy/srfit/equation/literals/operators.py
+++ b/src/diffpy/srfit/equation/literals/operators.py
@@ -28,8 +28,7 @@ but they all identify themselves with the Visitor.onOperator method.
 __all__ = ["Operator", "AdditionOperator", "SubtractionOperator",
            "MultiplicationOperator", "DivisionOperator", "ExponentiationOperator",
            "RemainderOperator", "NegationOperator", "ConvolutionOperator",
-           "SumOperator", "UFuncOperator", "ListOperator", "SetOperator",
-           "ArrayOperator", "PolyvalOperator"]
+           "SumOperator", "UFuncOperator", "ArrayOperator", "PolyvalOperator"]
 
 import numpy
 
@@ -348,34 +347,6 @@ class UFuncOperator(Operator):
         self.nout = op.nout
         self.operation = op
         return
-
-
-class ListOperator(Operator):
-    """Operator that will take parameters and turn them into a list."""
-
-    name = "list"
-    symbol = "list"
-    nin = -1
-    nout = 1
-
-    @staticmethod
-    def operation(*args):
-        """Convert arguments into a list."""
-        return args
-
-
-class SetOperator(Operator):
-    """Operator that will take parameters and turn them into a set."""
-
-    name = "set"
-    symbol = "set"
-    nin = -1
-    nout = 1
-
-    @staticmethod
-    def operation(*args):
-        """Convert arguments into a set."""
-        return set(args)
 
 
 class ArrayOperator(Operator):

--- a/src/diffpy/srfit/fitbase/calculator.py
+++ b/src/diffpy/srfit/fitbase/calculator.py
@@ -60,16 +60,26 @@ class Calculator(Operator, ParameterSet):
     Properties
     names           --  Variable names (read only). See getNames.
     values          --  Variable values (read only). See getValues.
-
     """
+
+    # define abstract attributes from the Operator base.
+
+    nin = -1
+    nout = 1
 
     def __init__(self, name):
         ParameterSet.__init__(self, name)
         self.meta = {}
 
         # Initialize Operator attributes
-        Operator.__init__(self, name, name, self.operation, -1, 1)
+        Operator.__init__(self, name)
         return
+
+
+    @property
+    def symbol(self):
+        return self.name
+
 
     # Overload me!
     def __call__(self, *args):
@@ -82,9 +92,11 @@ class Calculator(Operator, ParameterSet):
         """
         return 0
 
+
     def operation(self, *args):
         self._value = self.__call__(*args)
         return self._value
+
 
     def _validate(self):
         """Validate my state.

--- a/src/diffpy/srfit/fitbase/profilegenerator.py
+++ b/src/diffpy/srfit/fitbase/profilegenerator.py
@@ -126,12 +126,11 @@ class ProfileGenerator(Operator, ParameterSet):
     def operation(self):
         """Evaluate the profile.
 
-        This calls __call__ and passes in profile.x. It also stores the output
-        in profile.ycalc. The calculated value is then returned.
-
+        Return the result of __call__(profile.x).
         """
         y = self.__call__(self.profile.x)
         return y
+
 
     def setProfile(self, profile):
         """Assign the profile.

--- a/src/diffpy/srfit/fitbase/profilegenerator.py
+++ b/src/diffpy/srfit/fitbase/profilegenerator.py
@@ -89,20 +89,28 @@ class ProfileGenerator(Operator, ParameterSet):
     Properties
     names           --  Variable names (read only). See getNames.
     values          --  Variable values (read only). See getValues.
-
     """
+
+    # define abstract attributes from the Operator base.
+    nin = 0
+    nout = 1
+
 
     def __init__(self, name):
         """Initialize the attributes."""
+        Operator.__init__(self)
         ParameterSet.__init__(self, name)
         self.profile = None
         self.meta = {}
-
-        # Operator attributes
-        Operator.__init__(self, name, name, self.operation, 0, 1)
         return
 
+
+    @property
+    def symbol(self):
+        return self.name
+
     # Overload me!
+
     def __call__(self, x):
         """Evaluate the profile.
 

--- a/src/diffpy/srfit/structure/diffpyparset.py
+++ b/src/diffpy/srfit/structure/diffpyparset.py
@@ -137,10 +137,10 @@ class DiffpyAtomParSet(ParameterSet):
         self.addParameter(B23)
         self.addParameter(B32)
         self.addParameter(ParameterAdapter("Biso", a, attr = "Bisoequiv"))
-
-        # Other setup
-        self.__repr__ = a.__repr__
         return
+
+    def __repr__(self):
+        return repr(self.atom)
 
     def _getElem(self):
         return self.atom.element
@@ -198,12 +198,13 @@ class DiffpyLatticeParSet(ParameterSet):
             _latsetter("beta")))
         self.addParameter(ParameterAdapter("gamma", l, _latgetter("gamma"),
             _latsetter("gamma")))
-
-        # Other setup
-        self.__repr__ = l.__repr__
         return
 
+    def __repr__(self):
+        return repr(self.lattice)
+
 # End class DiffpyLatticeParSet
+
 
 class DiffpyStructureParSet(SrRealParSet):
     """A wrapper for diffpy.Structure.Structure.
@@ -287,6 +288,5 @@ class DiffpyStructureParSet(SrRealParSet):
         from diffpy.srreal.structureadapter import nometa
         stru = SrRealParSet._getSrRealStructure(self)
         return nometa(stru)
-
 
 # End class DiffpyStructureParSet

--- a/src/diffpy/srfit/tests/testcontribution.py
+++ b/src/diffpy/srfit/tests/testcontribution.py
@@ -145,6 +145,8 @@ class TestContribution(unittest.TestCase):
         self.assertEqual(len(xobs2), len(fc.residual()))
         return
 
+
+    @unittest.expectedFailure
     def testResidual(self):
         """Test the residual, which requires all other methods."""
         fc = self.fitcontribution

--- a/src/diffpy/srfit/tests/testcontribution.py
+++ b/src/diffpy/srfit/tests/testcontribution.py
@@ -146,7 +146,6 @@ class TestContribution(unittest.TestCase):
         return
 
 
-    @unittest.expectedFailure
     def testResidual(self):
         """Test the residual, which requires all other methods."""
         fc = self.fitcontribution

--- a/src/diffpy/srfit/tests/testdiffpyparset.py
+++ b/src/diffpy/srfit/tests/testdiffpyparset.py
@@ -16,6 +16,7 @@
 """Tests for diffpy.srfit.structure package."""
 
 import unittest
+import pickle
 
 import numpy
 
@@ -31,6 +32,7 @@ class TestParameterAdapter(testoptional(TestCaseStructure)):
         global Atom, Lattice, Structure, DiffpyStructureParSet
         from diffpy.Structure import Atom, Lattice, Structure
         from diffpy.srfit.structure.diffpyparset import DiffpyStructureParSet
+
 
     def testDiffpyStructureParSet(self):
         """Test the structure conversion."""
@@ -108,6 +110,33 @@ class TestParameterAdapter(testoptional(TestCaseStructure)):
         self.assertNotEquals(d, dsstru.lattice.dist(a1.xyz, a2.xyz))
         return
 
+
+    def test___repr__(self):
+        """Test representation of DiffpyStructureParSet objects.
+        """
+        lat = Lattice(3, 3, 2, 90, 90, 90)
+        atom = Atom("C", [0, 0.2, 0.5])
+        stru = Structure([atom], lattice=lat)
+        dsps = DiffpyStructureParSet("dsps", stru)
+        self.assertEqual(repr(stru), repr(dsps))
+        self.assertEqual(repr(lat), repr(dsps.lattice))
+        self.assertEqual(repr(atom), repr(dsps.atoms[0]))
+        return
+
+
+    @unittest.expectedFailure
+    def test_pickling(self):
+        """Test pickling of DiffpyStructureParSet.
+        """
+        stru = Structure([Atom("C", [0, 0.2, 0.5])])
+        dsps = DiffpyStructureParSet("dsps", stru)
+        data = pickle.dumps(dsps)
+        dsps2 = pickle.loads(data)
+        self.assertEqual(1, len(dsps2.atoms))
+        self.assertEqual(0.2, dsps2.atoms[0].y.value)
+        return
+
+# End of class TestParameterAdapter
 
 
 if __name__ == "__main__":

--- a/src/diffpy/srfit/tests/testdiffpyparset.py
+++ b/src/diffpy/srfit/tests/testdiffpyparset.py
@@ -124,7 +124,6 @@ class TestParameterAdapter(testoptional(TestCaseStructure)):
         return
 
 
-    @unittest.expectedFailure
     def test_pickling(self):
         """Test pickling of DiffpyStructureParSet.
         """

--- a/src/diffpy/srfit/tests/testfitrecipe.py
+++ b/src/diffpy/srfit/tests/testfitrecipe.py
@@ -142,6 +142,8 @@ class TestFitRecipe(unittest.TestCase):
         self.assertTrue(2 in values)
         return
 
+
+    @unittest.expectedFailure
     def testResidual(self):
         """Test the residual and everything that can change it."""
 

--- a/src/diffpy/srfit/tests/testfitrecipe.py
+++ b/src/diffpy/srfit/tests/testfitrecipe.py
@@ -143,7 +143,6 @@ class TestFitRecipe(unittest.TestCase):
         return
 
 
-    @unittest.expectedFailure
     def testResidual(self):
         """Test the residual and everything that can change it."""
 

--- a/src/diffpy/srfit/tests/testliterals.py
+++ b/src/diffpy/srfit/tests/testliterals.py
@@ -56,12 +56,18 @@ class TestArgument(unittest.TestCase):
         self.assertAlmostEqual(3.14, a.getValue())
         return
 
-class TestOperator(unittest.TestCase):
+class TestCustomOperator(unittest.TestCase):
+
+
+    def setUp(self):
+        self.op = literals.makeOperator(
+            name="add", symbol="+", operation=numpy.add, nin=2, nout=1)
+        return
+
 
     def testInit(self):
         """Test that everthing initializes as expected."""
-        op = literals.Operator(symbol = "+", operation = numpy.add, nin = 2)
-
+        op = self.op
         self.assertEqual("+", op.symbol)
         self.assertEqual(numpy.add, op.operation)
         self.assertEqual(2, op.nin)
@@ -70,17 +76,19 @@ class TestOperator(unittest.TestCase):
         self.assertEqual([], op.args)
         return
 
+
     def testIdentity(self):
         """Make sure an Argument is an Argument."""
-        op = literals.Operator(symbol = "+", operation = numpy.add, nin = 2)
+        op = self.op
         self.assertTrue(issubclass(literals.Operator, abcs.OperatorABC))
         self.assertTrue(isinstance(op, abcs.OperatorABC))
         return
 
+
     def testValue(self):
         """Test value."""
         # Test addition and operations
-        op = literals.Operator(symbol = "+", operation = numpy.add, nin = 2)
+        op = self.op
         a = literals.Argument(value = 0)
         b = literals.Argument(value = 0)
 
@@ -101,10 +109,10 @@ class TestOperator(unittest.TestCase):
 
         return
 
+
     def testAddLiteral(self):
         """Test adding a literal to an operator node."""
-        op = literals.Operator(name = "add", symbol = "+", operation =
-                numpy.add, nin = 2, nout = 1)
+        op = self.op
 
         self.assertRaises(ValueError, op.getValue)
         op._value = 1
@@ -128,18 +136,19 @@ class TestOperator(unittest.TestCase):
         # Test for self-references
 
         # Try to add self
-        op = literals.Operator(name = "add", symbol = "+", operation =
-                numpy.add, nin = 2, nout = 1)
-        op.addLiteral(a)
-        self.assertRaises(ValueError, op.addLiteral, op)
+        op1 = literals.makeOperator(name="add", symbol="+",
+                                    operation=numpy.add, nin=2, nout=1)
+        op1.addLiteral(a)
+        self.assertRaises(ValueError, op1.addLiteral, op1)
 
         # Try to add argument that contains self
-        op2 = literals.Operator(name = "sub", symbol = "-", operation =
-                numpy.subtract, nin = 2, nout = 1)
-        op2.addLiteral(op)
-        self.assertRaises(ValueError, op.addLiteral, op2)
+        op2 = literals.makeOperator(
+            name="sub", symbol="-", operation=numpy.subtract, nin=2, nout=1)
+        op2.addLiteral(op1)
+        self.assertRaises(ValueError, op1.addLiteral, op2)
 
         return
+
 
 class TestConvolutionOperator(unittest.TestCase):
 

--- a/src/diffpy/srfit/tests/testliterals.py
+++ b/src/diffpy/srfit/tests/testliterals.py
@@ -22,6 +22,7 @@ import numpy
 import diffpy.srfit.equation.literals as literals
 import diffpy.srfit.equation.literals.abcs as abcs
 
+# ----------------------------------------------------------------------------
 
 class TestArgument(unittest.TestCase):
 
@@ -33,12 +34,14 @@ class TestArgument(unittest.TestCase):
         self.assertTrue(None is a.name)
         return
 
+
     def testIdentity(self):
         """Make sure an Argument is an Argument."""
         a = literals.Argument()
         self.assertTrue(issubclass(literals.Argument, abcs.ArgumentABC))
         self.assertTrue(isinstance(a, abcs.ArgumentABC))
         return
+
 
     def testValue(self):
         """Test value setting."""
@@ -56,8 +59,9 @@ class TestArgument(unittest.TestCase):
         self.assertAlmostEqual(3.14, a.getValue())
         return
 
-class TestCustomOperator(unittest.TestCase):
+# ----------------------------------------------------------------------------
 
+class TestCustomOperator(unittest.TestCase):
 
     def setUp(self):
         self.op = literals.makeOperator(
@@ -149,6 +153,7 @@ class TestCustomOperator(unittest.TestCase):
 
         return
 
+# ----------------------------------------------------------------------------
 
 class TestConvolutionOperator(unittest.TestCase):
 
@@ -184,6 +189,7 @@ class TestConvolutionOperator(unittest.TestCase):
         self.assertAlmostEqual(0, sum((g3-g3c)**2))
         return
 
+# ----------------------------------------------------------------------------
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/diffpy/srfit/tests/testliterals.py
+++ b/src/diffpy/srfit/tests/testliterals.py
@@ -13,7 +13,7 @@
 #
 ##############################################################################
 
-"""Tests for refinableobj module."""
+"""Tests for the diffpy.srfit.equation.literals module."""
 
 import unittest
 
@@ -187,6 +187,30 @@ class TestConvolutionOperator(unittest.TestCase):
 
         self.assertAlmostEqual(sum(g3c), sum(g3))
         self.assertAlmostEqual(0, sum((g3-g3c)**2))
+        return
+
+# ----------------------------------------------------------------------------
+
+class TestArrayOperator(unittest.TestCase):
+
+    def test_value(self):
+        """Check ArrayOperator.value.
+        """
+        x = literals.Argument('x', 1.0)
+        y = literals.Argument('y', 2.0)
+        z = literals.Argument('z', 3.0)
+        # check empty array
+        op = literals.ArrayOperator()
+        self.assertEqual(0, len(op.value))
+        self.assertTrue(isinstance(op.value, numpy.ndarray))
+        # check behavior with 2 arguments
+        op.addLiteral(x)
+        self.assertTrue(numpy.array_equal([1], op.value))
+        op.addLiteral(y)
+        op.addLiteral(z)
+        self.assertTrue(numpy.array_equal([1, 2, 3], op.value))
+        z.value = 7
+        self.assertTrue(numpy.array_equal([1, 2, 7], op.value))
         return
 
 # ----------------------------------------------------------------------------

--- a/src/diffpy/srfit/tests/testprofilegenerator.py
+++ b/src/diffpy/srfit/tests/testprofilegenerator.py
@@ -13,8 +13,9 @@
 #
 ##############################################################################
 
-"""Tests for refinableobj module."""
+"""Tests for profilegenerator module."""
 
+import pickle
 import unittest
 
 from numpy import arange, array_equal
@@ -33,6 +34,7 @@ class TestProfileGenerator(unittest.TestCase):
         self.gen.setProfile(self.profile)
         return
 
+
     def testOperation(self):
         """Test the operation method."""
         gen = self.gen
@@ -46,6 +48,7 @@ class TestProfileGenerator(unittest.TestCase):
         val = gen(2 * prof.x)
         self.assertTrue(array_equal(2 * prof.x, val))
         return
+
 
     def testUpdate(self):
         """Update and change the profile to make sure generator is flushed."""
@@ -74,6 +77,19 @@ class TestProfileGenerator(unittest.TestCase):
         self.assertTrue(array_equal(x, gen.value))
         return
 
+
+    def test_pickling(self):
+        """Test pickling of ProfileGenerator.
+        """
+        data = pickle.dumps(self.gen)
+        gen2 = pickle.loads(data)
+        self.assertEqual('test', gen2.name)
+        x = self.profile.x
+        self.assertTrue(array_equal(x, gen2.operation()))
+        self.assertTrue(array_equal(3 * x, gen2(3 * x)))
+        return
+
+# End of class TestProfileGenerator
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/diffpy/srfit/tests/testweakrefcallable.py
+++ b/src/diffpy/srfit/tests/testweakrefcallable.py
@@ -121,6 +121,31 @@ class TestWeakBoundMethod(unittest.TestCase):
         self.assertTrue(feq2 is w2._wref())
         return
 
+
+    def test_observable_deregistration(self):
+        """check if Observable drops dead Observer.
+        """
+        f = self.f
+        x = f.newParameter('x', 5)
+        f.setEquation('3 * x')
+        self.assertEqual(15, f.evaluate())
+        self.assertEqual(15, f._eq._value)
+        # get one of the observer callables that are associated with f
+        xof = next(iter(x._observers))
+        self.assertTrue(isinstance(xof, WeakBoundMethod))
+        # changing value of x should reset f._eq
+        x.setValue(x.value + 1)
+        self.assertTrue(None is f._eq._value)
+        self.assertEqual(18, f.evaluate())
+        # deallocate f now
+        self.f = f = None
+        self.assertTrue(xof in x._observers)
+        # since f does not exist anymore, the next notification call
+        # should drop the associated observer.
+        x.setValue(x.value + 1)
+        self.assertEqual(0, len(x._observers))
+        return
+
 # End of class TestWeakBoundMethod
 
 # Local Routines -------------------------------------------------------------

--- a/src/diffpy/srfit/tests/testweakrefcallable.py
+++ b/src/diffpy/srfit/tests/testweakrefcallable.py
@@ -22,7 +22,8 @@ import unittest
 import pickle
 
 from diffpy.srfit.fitbase import FitContribution
-from diffpy.srfit.util.weakrefcallable import weak_ref
+from diffpy.srfit.fitbase.parameter import Parameter
+from diffpy.srfit.util.weakrefcallable import weak_ref, WeakBoundMethod
 
 # ----------------------------------------------------------------------------
 
@@ -30,26 +31,27 @@ class TestWeakBoundMethod(unittest.TestCase):
 
     def setUp(self):
         self.f = FitContribution('f')
-        self.holder = set()
-        self.w = weak_ref(self.f._flush, holder=self.holder)
-        self.holder.add(self.w)
+        self.f.setEquation('7')
+        self.w = weak_ref(self.f._eq._flush, fallback=_fallback_example)
         return
 
 
     def tearDown(self):
-        self.assertTrue(self.w in self.holder)
         self.f = None
-        self.assertTrue(None is self.w('any', 'argument'))
-        self.assertFalse(self.w in self.holder)
+        self.assertTrue(None is self.w._wref())
+        obj, args, kw = self.w('any', 'argument', foo=37)
+        self.assertTrue(obj is self.w)
+        self.assertEqual(('any', 'argument'), args)
+        self.assertEqual({'foo' : 37}, kw)
         return
 
 
     def test___init__(self):
         """check WeakBoundMethod.__init__()
         """
-        # make sure there is no 'weak object has gone away' warning.
-        wf = weak_ref(self.f._flush, holder=self.holder)
-        del wf
+        self.assertTrue(self.w.fallback is _fallback_example)
+        wf = weak_ref(self.f._flush)
+        self.assertTrue(None is wf.fallback)
         return
 
 
@@ -57,18 +59,17 @@ class TestWeakBoundMethod(unittest.TestCase):
         """check WeakBoundMethod.__call__()
         """
         f = self.f
-        f.newParameter('x', 5)
-        f.setEquation('3 * x')
-        wx = weak_ref(f._eq._flush, holder=self.holder)
-        self.holder.add(wx)
-        self.assertEqual(15, f.evaluate())
-        self.assertEqual(15, f._eq._value)
-        wx(())
+        self.assertEqual(7, f.evaluate())
+        self.assertEqual(7, f._eq._value)
+        # verify f has the same effect as f._eq._flush
+        self.w(())
         self.assertTrue(None is f._eq._value)
-        self.assertEqual(15, f.evaluate())
-        self.assertTrue(wx in self.holder)
-        f.setEquation('2 * t')
-        self.assertFalse(wx in self.holder)
+        # check WeakBoundMethod behavior with no fallback
+        x = Parameter('x', value=3)
+        wgetx = weak_ref(x.getValue)
+        self.assertEqual(3, wgetx())
+        del x
+        self.assertRaises(ReferenceError, wgetx)
         return
 
 
@@ -107,7 +108,26 @@ class TestWeakBoundMethod(unittest.TestCase):
         self.assertEqual(w1, w1cc)
         return
 
+
+    def test_pickling(self):
+        """Verify unpickling works when it involves __hash__ call.
+        """
+        holder = set([self.w])
+        objs = [holder, self.f._eq, self.w]
+        data = pickle.dumps(objs)
+        objs2 = pickle.loads(data)
+        h2, feq2, w2 = objs2
+        self.assertTrue(w2 in h2)
+        self.assertTrue(feq2 is w2._wref())
+        return
+
 # End of class TestWeakBoundMethod
+
+# Local Routines -------------------------------------------------------------
+
+def _fallback_example(wbm, *args, **kwargs):
+    return (wbm, args, kwargs)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/diffpy/srfit/util/observable.py
+++ b/src/diffpy/srfit/util/observable.py
@@ -57,7 +57,7 @@ class Observable(object):
         """
         Add callable to the set of observers
         """
-        f = weak_ref(callable)
+        f = weak_ref(callable, fallback=_fbRemoveObserver)
         self._observers.add(f)
         return
 
@@ -86,5 +86,16 @@ class Observable(object):
         self._observers = set()
         return
 
+# end of class Observable
+
+# Local helpers --------------------------------------------------------------
+
+def _fbRemoveObserver(fobs, semaphors):
+    # Remove WeakBoundMethod `fobs` from the observers of notifying object.
+    # This is called from Observable.notify when the WeakBoundMethod
+    # associated object dies.
+    observable = semaphors[0]
+    observable.removeObserver(fobs)
+    return
 
 # end of file

--- a/src/diffpy/srfit/util/observable.py
+++ b/src/diffpy/srfit/util/observable.py
@@ -57,7 +57,7 @@ class Observable(object):
         """
         Add callable to the set of observers
         """
-        f = weak_ref(callable, holder=self._observers)
+        f = weak_ref(callable)
         self._observers.add(f)
         return
 
@@ -85,10 +85,6 @@ class Observable(object):
         super(Observable, self).__init__(**kwds)
         self._observers = set()
         return
-
-
-    # private data
-    _observers = None
 
 
 # end of file

--- a/src/diffpy/srfit/util/weakrefcallable.py
+++ b/src/diffpy/srfit/util/weakrefcallable.py
@@ -28,15 +28,19 @@ class WeakBoundMethod(object):
     Callable wrapper to a bound method stored as a weak reference.
 
     Support storage of bound methods without keeping the associated objects
-    alive forever.  Remove this wrapper from an optional holder set when
-    the method object is to be finalized.
+    alive forever.  Provide facility for a fallback function to be used
+    when method-related object is deleted.
 
     Attributes
     ----------
     function : MethodType
         the unbound function extracted from the wrapped bound method.
-    holder : set, optional
-        set that should drop this wrapper when it becomes inactive.
+    fallback : FunctionType, optional
+        plain function to be called when object holding the bound method
+        gets deallocated.  The fallback function is called with this
+        object as the first argument followed by any positional and
+        keyword arguments passed for the bound method.  The fallback
+        function can be used to deregister this wrapper.
     _wref : weakref
         weak reference to the object the wrapped method is bound to.
     _class : type
@@ -44,46 +48,52 @@ class WeakBoundMethod(object):
         This is only used for pickling.
     """
 
-    __slots__ = ('function', 'holder', '_wref', '_class')
+    __slots__ = ('function', 'fallback', '_wref', '_class')
 
-    def __init__(self, f, holder=None):
+    def __init__(self, f, fallback=None):
         """Create a weak reference wrapper to bound method.
 
         Parameters
         ----------
         f : bound MethodType
             instance-bound method to be wrapped.
-        holder : set, optional
-            set which should discard this object when the method
-            associated object gets deallocated.
+        fallback : FunctionType, optional
+            plain function to be called instead of the bound method when
+            the method associated object gets deallocated.
         """
         # This does not handle builtin methods, but that can be added
         # if necessary.
         self.function = f.__func__
-        self.holder = holder
-        cb = self.__make_callback(self.holder)
+        self.fallback = fallback
         self._class = type(f.__self__)
-        self._wref = weakref.ref(f.__self__, cb)
+        self._wref = weakref.ref(f.__self__)
         return
 
 
     def __call__(self, *args, **kwargs):
         """Call the wrapped method if the weak-referenced object is alive.
 
-        If that object does not exist, remove this wrapper from the holder
-        set and return None.
+        If that object does not exist and the fallback function is defined,
+        call the fallback function instead.
 
         Parameters
         ----------
         *args, **kwargs
             same arguments as for the wrapped bound method.
+
+        Raises
+        ------
+        ReferenceError
+            when the method-bound object does not exist and the fallback
+            function is not defined.
         """
         mobj = self._wref()
-        if mobj is None:
-            if self.holder is not None:
-                self.holder.discard(self)
-            return None
-        return self.function(mobj, *args, **kwargs)
+        if mobj is not None:
+            return self.function(mobj, *args, **kwargs)
+        if self.fallback is not None:
+            return self.fallback(self, *args, **kwargs)
+        emsg = "Object bound to {} does not exist.".format(self.function)
+        raise ReferenceError(emsg)
 
 
     # support use of this class in hashed collections
@@ -111,22 +121,21 @@ class WeakBoundMethod(object):
         nm = self.function.__name__
         assert self.function is getattr(self._class, nm), \
             "Unable to pickle this unbound function by name."
-        state = (self._class, nm, self.holder, mobj)
+        state = (self._class, nm, self.fallback, mobj)
         return state
 
 
     def __setstate__(self, state):
         """Restore the weak reference in this wrapper upon unpickling.
         """
-        (self._class, nm, self.holder, mobj) = state
+        (self._class, nm, self.fallback, mobj) = state
         self.function = getattr(self._class, nm)
         if mobj is None:
             # use a fake weak reference that mimics deallocated object.
             self._wref = self.__mimic_empty_ref
             return
         # Here the referred object exists.
-        cb = self.__make_callback(self.holder)
-        self._wref = weakref.ref(mobj, cb)
+        self._wref = weakref.ref(mobj)
         return
 
 
@@ -134,41 +143,34 @@ class WeakBoundMethod(object):
     def __mimic_empty_ref():
         return None
 
-
-    @staticmethod
-    def __make_callback(holder):
-        if holder is None:
-            return None
-        def cb(wref):
-            holder.difference_update([
-                m for m in holder
-                if isinstance(m, WeakBoundMethod) and m._wref == wref])
-        return cb
-
 # end of class WeakBoundMethod
 
 # ----------------------------------------------------------------------------
 
-def weak_ref(f, holder=None):
+def weak_ref(f, fallback=None):
     """Create weak-reference wrapper to a bound method.
 
     Parameters
     ----------
     f : callable
         object-bound method or a plain function.
-    holder : set, optional
-        set that should drop the returned wrapper when the `f`
-        gets deallocated.
+    fallback : FunctionType, optional
+        plain function to be called when object holding ``f`` gets
+        deallocated.  The fallback function is called with the
+        wrapper object as the first argument followed by positional
+        and keyword arguments passed for the bound method.  The
+        fallback function can be used to deregister the wrapper.
 
     Returns
     -------
     WeakBoundMethod
-        when `f` is a bound method.  If `f` is a plain function,
-        return `f` and ignore the `holder` argument.
+        when `f` is a bound method.  If `f` is a plain function or
+        already of WeakBoundMethod type, return `f` and ignore the
+        `fallback` argument.
     """
     # NOTE Weak referencing plain functions is probably not needed,
     # because they are already bound to the defining modules.
     rv = f
     if isinstance(f, (types.MethodType, types.BuiltinMethodType)):
-        rv = WeakBoundMethod(f, holder=holder)
+        rv = WeakBoundMethod(f, fallback=fallback)
     return rv


### PR DESCRIPTION
Apply fix for #32 from the master branch.

* refactor WeakBoundMethod to use fallback call function when the method-bound object dies.  
* remove WeakBoundMethod.holder set that held self.  Bad for pickling.
* refactor Operator classes so they don't store bound method in instance dictionary.
* remove unused ListOperator and SetOperator classes.

In sync with 5e2e19d690f58e638c1b59dc92ba39393cd96a89.
