### PR TITLE
Clean saved results

### DIFF
--- a/src/diffpy/srfit/fitbase/fitresults.py
+++ b/src/diffpy/srfit/fitbase/fitresults.py
@@ -499,15 +499,7 @@ class FitResults(object):
         header  --  A header to add to the output (default "")
         footer  --  A footer to add to the output (default "")
         update  --  Flag indicating whether to call update() (default False).
-
         """
-        # Save the time and user
-        from time import ctime
-        from getpass import getuser
-        myheader = "Results written: " + ctime() + "\n"
-        myheader += "produced by " + getuser() + "\n"
-        header = myheader + header
-
         res = self.formatResults(header, footer, update)
         f = open(filename, 'w')
         f.write(res)

--- a/src/diffpy/srfit/tests/testfitresults.py
+++ b/src/diffpy/srfit/tests/testfitresults.py
@@ -18,9 +18,42 @@
 import unittest
 
 from diffpy.srfit.fitbase.fitrecipe import FitRecipe
+from diffpy.srfit.fitbase.fitresults import FitResults
 from diffpy.srfit.fitbase.fitresults import initializeRecipe
 from diffpy.srfit.tests.utils import datafile
+from diffpy.srfit.tests.utils import capturefilewrite
 
+# ----------------------------------------------------------------------------
+
+class TestFitResults(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        blankfit = FitRecipe()
+        cls.blank = FitResults(blankfit)
+        return
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.blank = None
+        return
+
+    def setUp(self):
+        return
+
+
+    @unittest.expectedFailure
+    def test_saveResults(self):
+        "check FitResults.saveResults()"
+        txt = capturefilewrite(self.blank.saveResults)
+        lines = txt.split('\n')
+        self.assertFalse(lines[0].startswith('Results written'))
+        self.assertFalse(lines[0].startswith('produced by'))
+        return
+
+# end of class TestFitResults
+
+# ----------------------------------------------------------------------------
 
 class TestInitializeRecipe(unittest.TestCase):
 
@@ -76,6 +109,9 @@ class TestInitializeRecipe(unittest.TestCase):
         self.assertAlmostEqual(self.x0val, recipe.x0.value)
         return
 
-if __name__ == "__main__":
+# end of class TestInitializeRecipe
 
+# ----------------------------------------------------------------------------
+
+if __name__ == "__main__":
     unittest.main()

--- a/src/diffpy/srfit/tests/testfitresults.py
+++ b/src/diffpy/srfit/tests/testfitresults.py
@@ -42,7 +42,6 @@ class TestFitResults(unittest.TestCase):
         return
 
 
-    @unittest.expectedFailure
     def test_saveResults(self):
         "check FitResults.saveResults()"
         txt = capturefilewrite(self.blank.saveResults)

--- a/src/diffpy/srfit/tests/utils.py
+++ b/src/diffpy/srfit/tests/utils.py
@@ -16,6 +16,9 @@
 """Helper routines for testing."""
 
 import sys
+import os.path
+import tempfile
+
 import six
 
 import diffpy.srfit.equation.literals as literals
@@ -109,4 +112,34 @@ def capturestdout(f, *args, **kwargs):
         sys.stdout = savestdout
     return fp.getvalue()
 
-# End of file
+
+def capturefilewrite(f, *args, **kwargs):
+    """Capture output written by function to a temporary file.
+
+    Parameters
+    ----------
+    f : callable
+        The function which writes output to some file path.
+        It must take filename as its first argument.
+
+    Returns
+    -------
+    content : str
+        The content written to the file by the `f` call.
+
+    Raises
+    ------
+    FileNotFoundError
+        When `f` call does not write the specified file argument.
+    """
+    tf = tempfile.NamedTemporaryFile()
+    tf.close()
+    assert not os.path.exists(tf.name)
+    try:
+        f(tf.name, *args, **kwargs)
+        with open(tf.name) as fp:
+            rv = fp.read()
+    finally:
+        if os.path.exists(tf.name):
+            os.remove(tf.name)
+    return rv


### PR DESCRIPTION
Not yet ready - for CI reports only.

- [x] drop date and username cruft from results output
- [ ] remove trailing blanks in constrained parameters section