### PR TITLE
Pass unit tests on Python 3.7

### DIFF
--- a/src/diffpy/srfit/tests/testliterals.py
+++ b/src/diffpy/srfit/tests/testliterals.py
@@ -118,7 +118,7 @@ class TestCustomOperator(unittest.TestCase):
         """Test adding a literal to an operator node."""
         op = self.op
 
-        self.assertRaises(ValueError, op.getValue)
+        self.assertRaises(TypeError, op.getValue)
         op._value = 1
         self.assertEqual(op.getValue(), 1)
 
@@ -127,7 +127,7 @@ class TestCustomOperator(unittest.TestCase):
         b = literals.Argument(name = "b", value = 0)
 
         op.addLiteral(a)
-        self.assertRaises(ValueError, op.getValue)
+        self.assertRaises(TypeError, op.getValue)
 
         op.addLiteral(b)
         self.assertAlmostEqual(0, op.value)

--- a/src/diffpy/srfit/tests/testvisitors.py
+++ b/src/diffpy/srfit/tests/testvisitors.py
@@ -195,7 +195,7 @@ class TestSwapper(unittest.TestCase):
         self.assertTrue(plus2.hasObserver(mult._flush))
 
         # plus2 has no arguments yet. Verify this.
-        self.assertRaises(ValueError, mult.getValue)
+        self.assertRaises(TypeError, mult.getValue)
         # Add the arguments to plus2.
         plus2.addLiteral(v4)
         plus2.addLiteral(v5)


### PR DESCRIPTION
The PR fixes two 2 failed test cases using the `diffpy-cmi` Conda environment

When `op._value = None`, `getValue()` returns `TypeError` instead of `ValueError`.

Ideally, we use `ValueError` as it was originally; we shall backburner this after we do cookiecutting. I will leave an issue. 


## Local test:

All 110 tests pass.

```
imac@imacs-iMac diffpy.srfit % python -m diffpy.srfit.tests.run
WARNING:diffpy.srfit.tests:No module named 'sas', SaS tests skipped.
WARNING:diffpy.srfit.tests:Cannot import diffpy.structure, Structure tests skipped.
WARNING:diffpy.srfit.tests:Cannot import pyobjcryst, pyobjcryst tests skipped.
WARNING:diffpy.srfit.tests:Cannot import diffpy.srreal, PDF tests skipped.
......ssss...........sss..................sssssssssss....ssssss...........................ssssss..............
----------------------------------------------------------------------
Ran 110 tests in 0.184s
```

Conda enviornment (used `conda install diffpy-cmi`)

```
# Name                    Version                   Build  Channel
ca-certificates           2024.7.4             h8857fd0_0    conda-forge
diffpy-srfit              3.0.0.post10             pypi_0    pypi
libcxx                    18.1.8               heced48a_4    conda-forge
libffi                    3.4.2                h0d85af4_5    conda-forge
libsqlite                 3.46.0               h1b8f9f3_0    conda-forge
libzlib                   1.3.1                h87427d6_1    conda-forge
ncurses                   6.5                  h5846eda_0    conda-forge
numpy                     1.21.6                   pypi_0    pypi
openssl                   3.3.1                h87427d6_2    conda-forge
pip                       24.0               pyhd8ed1ab_0    conda-forge
python                    3.7.12          hf3644f1_100_cpython    conda-forge
readline                  8.2                  h9e318b2_1    conda-forge
setuptools                69.0.3             pyhd8ed1ab_0    conda-forge
sqlite                    3.46.0               h28673e1_0    conda-forge
tk                        8.6.13               h1abcd95_1    conda-forge
wheel                     0.42.0             pyhd8ed1ab_0    conda-forge
xz                        5.2.6                h775f41a_0    conda-forge
```

In the next PRs, I will submit flake8 autolinted for few files at a time.