### PR TITLE
Fix flake8 error of ambiguous name (E741)

### DIFF
--- a/src/diffpy/srfit/equation/builder.py
+++ b/src/diffpy/srfit/equation/builder.py
@@ -213,8 +213,7 @@ class EquationFactory(object):
         opbuilder = wrapFunction(name, func, len(argnames))
         for n in argnames:
             b = self.builders[n]
-            l = b.literal
-            opbuilder.literal.addLiteral(l)
+            opbuilder.literal.addLiteral(b.literal)
 
         return self.registerBuilder(name, opbuilder)
 

--- a/src/diffpy/srfit/fitbase/fitresults.py
+++ b/src/diffpy/srfit/fitbase/fitresults.py
@@ -173,8 +173,8 @@ class FitResults(object):
             self.cov = numpy.dot(vh.T.conj() / s**2, vh)
         except numpy.linalg.LinAlgError:
             self.messages.append("Cannot compute covariance matrix.")
-            l = len(self.varvals)
-            self.cov = numpy.zeros((l, l), dtype=float)
+            matrix_size = len(self.varvals)
+            self.cov = numpy.zeros((matrix_size, matrix_size), dtype=float)
         return
 
     def _calculateJacobian(self):
@@ -325,17 +325,17 @@ class FitResults(object):
             lines.append(header)
 
         if not certain:
-            l = "Some quantities invalid due to missing profile uncertainty"
-            if not l in self.messages:
-                self.messages.append(l)
+            error_message = "Some quantities invalid due to missing profile uncertainty"
+            if not error_message in self.messages:
+                self.messages.append(error_message)
 
         lines.extend(self.messages)
 
         ## Overall results
-        l = "Overall"
+        error_message = "Overall"
         if not certain:
-            l += " (Chi2 and Reduced Chi2 invalid)"
-        lines.append(l)
+            error_message += " (Chi2 and Reduced Chi2 invalid)"
+        lines.append(error_message)
         lines.append(_DASHEDLINE)
         formatstr = "%-14s %.8f"
         lines.append(formatstr % ("Residual", self.residual))
@@ -351,10 +351,10 @@ class FitResults(object):
             keys.sort(key=numstr)
 
             lines.append("")
-            l = "Contributions"
+            error_message = "Contributions"
             if not certain:
-                l += " (Chi2 and Reduced Chi2 invalid)"
-            lines.append(l)
+                error_message += " (Chi2 and Reduced Chi2 invalid)"
+            lines.append(error_message)
             lines.append(_DASHEDLINE)
             formatstr = "%-10s %-42.8f"
             for name in keys:
@@ -370,11 +370,11 @@ class FitResults(object):
         ## The variables
         if self.varnames:
             lines.append("")
-            l = "Variables"
+            error_message = "Variables"
             if not certain:
                 m = "Uncertainties invalid"
-                l += " (%s)" % m
-            lines.append(l)
+                error_message += " (%s)" % m
+            lines.append(error_message)
             lines.append(_DASHEDLINE)
 
             varnames = self.varnames
@@ -409,10 +409,10 @@ class FitResults(object):
         ## The constraints
         if self.connames and self.showcon:
             lines.append("")
-            l = "Constrained Parameters"
+            error_message = "Constrained Parameters"
             if not certain:
-                l += " (Uncertainties invalid)"
-            lines.append(l)
+                error_message += " (Uncertainties invalid)"
+            lines.append(error_message)
             lines.append(_DASHEDLINE)
 
             w = 0
@@ -438,10 +438,10 @@ class FitResults(object):
         ## Variable correlations
         lines.append("")
         corint = int(corrmin * 100)
-        l = "Variable Correlations greater than %i%%" % corint
+        error_message = "Variable Correlations greater than %i%%" % corint
         if not certain:
-            l += " (Correlations invalid)"
-        lines.append(l)
+            error_message += " (Correlations invalid)"
+        lines.append(error_message)
         lines.append(_DASHEDLINE)
         tup = []
         cornames = []

--- a/src/diffpy/srfit/sas/prcalculator.py
+++ b/src/diffpy/srfit/sas/prcalculator.py
@@ -92,8 +92,8 @@ class PrCalculator(Calculator):
         self._invertor.y = iq
         self._invertor.err = diq
         c, c_cov = self._invertor.invert_optimize()
-        l = lambda x: self._invertor.pr(c, x)
-        pr = map(l, r)
+        calculate_pr = lambda x: self._invertor.pr(c, x)
+        pr = map(calculate_pr, r)
 
         pr = numpy.array(pr)
         return self.scale.value * pr

--- a/src/diffpy/srfit/tests/testdiffpyparset.py
+++ b/src/diffpy/srfit/tests/testdiffpyparset.py
@@ -42,9 +42,9 @@ class TestParameterAdapter(unittest.TestCase):
 
         a1 = Atom("Cu", xyz=numpy.array([0.0, 0.1, 0.2]), Uisoequiv=0.003)
         a2 = Atom("Ag", xyz=numpy.array([0.3, 0.4, 0.5]), Uisoequiv=0.002)
-        l = Lattice(2.5, 2.5, 2.5, 90, 90, 90)
+        lattice = Lattice(2.5, 2.5, 2.5, 90, 90, 90)
 
-        dsstru = Structure([a1, a2], l)
+        dsstru = Structure([a1, a2], lattice)
         # Structure makes copies
         a1 = dsstru[0]
         a2 = dsstru[1]

--- a/src/diffpy/srfit/tests/testparameter.py
+++ b/src/diffpy/srfit/tests/testparameter.py
@@ -23,52 +23,52 @@ from diffpy.srfit.fitbase.parameter import Parameter, ParameterAdapter, Paramete
 class TestParameter(unittest.TestCase):
     def testSetValue(self):
         """Test initialization."""
-        l = Parameter("l")
+        l_parameter = Parameter("l")
 
-        l.setValue(3.14)
-        self.assertAlmostEqual(3.14, l.getValue())
+        l_parameter.setValue(3.14)
+        self.assertAlmostEqual(3.14, l_parameter.getValue())
 
         # Try array
         import numpy
 
         x = numpy.arange(0, 10, 0.1)
-        l.setValue(x)
-        self.assertTrue(l.getValue() is x)
-        self.assertTrue(l.value is x)
+        l_parameter.setValue(x)
+        self.assertTrue(l_parameter.getValue() is x)
+        self.assertTrue(l_parameter.value is x)
 
         # Change the array
         y = numpy.arange(0, 10, 0.5)
-        l.value = y
-        self.assertTrue(l.getValue() is y)
-        self.assertTrue(l.value is y)
+        l_parameter.value = y
+        self.assertTrue(l_parameter.getValue() is y)
+        self.assertTrue(l_parameter.value is y)
 
         # Back to scalar
-        l.setValue(1.01)
-        self.assertAlmostEqual(1.01, l.getValue())
-        self.assertAlmostEqual(1.01, l.value)
+        l_parameter.setValue(1.01)
+        self.assertAlmostEqual(1.01, l_parameter.getValue())
+        self.assertAlmostEqual(1.01, l_parameter.value)
         return
 
 
 class TestParameterProxy(unittest.TestCase):
     def testProxy(self):
         """Test the ParameterProxy class."""
-        l = Parameter("l", 3.14)
+        l_parameter = Parameter("l", 3.14)
 
         # Try Accessor adaptation
-        la = ParameterProxy("l2", l)
+        la = ParameterProxy("l2", l_parameter)
 
         self.assertEqual("l2", la.name)
-        self.assertEqual(l.getValue(), la.getValue())
+        self.assertEqual(l_parameter.getValue(), la.getValue())
 
         # Change the parameter
-        l.value = 2.3
-        self.assertEqual(l.getValue(), la.getValue())
-        self.assertEqual(l.value, la.value)
+        l_parameter.value = 2.3
+        self.assertEqual(l_parameter.getValue(), la.getValue())
+        self.assertEqual(l_parameter.value, la.value)
 
         # Change the proxy
         la.value = 3.2
-        self.assertEqual(l.getValue(), la.getValue())
-        self.assertEqual(l.value, la.value)
+        self.assertEqual(l_parameter.getValue(), la.getValue())
+        self.assertEqual(l_parameter.value, la.value)
 
         return
 
@@ -79,36 +79,36 @@ class TestParameterAdapter(unittest.TestCase):
 
         This adapts a Parameter to the Parameter interface. :)
         """
-        l = Parameter("l", 3.14)
+        l_parameter = Parameter("l", 3.14)
 
         # Try Accessor adaptation
-        la = ParameterAdapter("l", l, getter=Parameter.getValue, setter=Parameter.setValue)
+        la = ParameterAdapter("l", l_parameter, getter=Parameter.getValue, setter=Parameter.setValue)
 
-        self.assertEqual(l.name, la.name)
-        self.assertEqual(l.getValue(), la.getValue())
+        self.assertEqual(l_parameter.name, la.name)
+        self.assertEqual(l_parameter.getValue(), la.getValue())
 
         # Change the parameter
-        l.setValue(2.3)
-        self.assertEqual(l.getValue(), la.getValue())
+        l_parameter.setValue(2.3)
+        self.assertEqual(l_parameter.getValue(), la.getValue())
 
         # Change the adapter
         la.setValue(3.2)
-        self.assertEqual(l.getValue(), la.getValue())
+        self.assertEqual(l_parameter.getValue(), la.getValue())
 
         # Try Attribute adaptation
-        la = ParameterAdapter("l", l, attr="value")
+        la = ParameterAdapter("l", l_parameter, attr="value")
 
-        self.assertEqual(l.name, la.name)
+        self.assertEqual(l_parameter.name, la.name)
         self.assertEqual("value", la.attr)
-        self.assertEqual(l.getValue(), la.getValue())
+        self.assertEqual(l_parameter.getValue(), la.getValue())
 
         # Change the parameter
-        l.setValue(2.3)
-        self.assertEqual(l.getValue(), la.getValue())
+        l_parameter.setValue(2.3)
+        self.assertEqual(l_parameter.getValue(), la.getValue())
 
         # Change the adapter
         la.setValue(3.2)
-        self.assertEqual(l.getValue(), la.getValue())
+        self.assertEqual(l_parameter.getValue(), la.getValue())
 
         return
 

--- a/src/diffpy/srfit/tests/testsgconstraints.py
+++ b/src/diffpy/srfit/tests/testsgconstraints.py
@@ -54,18 +54,18 @@ class TestSGConstraints(unittest.TestCase):
         stru.sgpars.adppars
 
         # Check the orthorhombic lattice
-        l = stru.getLattice()
-        self.assertTrue(l.alpha.const)
-        self.assertTrue(l.beta.const)
-        self.assertTrue(l.gamma.const)
-        self.assertEqual(pi / 2, l.alpha.getValue())
-        self.assertEqual(pi / 2, l.beta.getValue())
-        self.assertEqual(pi / 2, l.gamma.getValue())
+        lattice = stru.getLattice()
+        self.assertTrue(lattice.alpha.const)
+        self.assertTrue(lattice.beta.const)
+        self.assertTrue(lattice.gamma.const)
+        self.assertEqual(pi / 2, lattice.alpha.getValue())
+        self.assertEqual(pi / 2, lattice.beta.getValue())
+        self.assertEqual(pi / 2, lattice.gamma.getValue())
 
-        self.assertFalse(l.a.const)
-        self.assertFalse(l.b.const)
-        self.assertFalse(l.c.const)
-        self.assertEqual(0, len(l._constraints))
+        self.assertFalse(lattice.a.const)
+        self.assertFalse(lattice.b.const)
+        self.assertFalse(lattice.c.const)
+        self.assertEqual(0, len(lattice._constraints))
 
         # Now make sure the scatterers are constrained properly
         scatterers = stru.getScatterers()


### PR DESCRIPTION
Please review flake8 errors on ambiguous variable names. Mostly "l" was used. 



And test passes (3.7)

```
OK (skipped=30)
imac@imacs-iMac diffpy.srfit % python -m diffpy.srfit.tests.run
WARNING:diffpy.srfit.tests:No module named 'sas', SaS tests skipped.
WARNING:diffpy.srfit.tests:Cannot import diffpy.structure, Structure tests skipped.
WARNING:diffpy.srfit.tests:Cannot import pyobjcryst, pyobjcryst tests skipped.
WARNING:diffpy.srfit.tests:Cannot import diffpy.srreal, PDF tests skipped.
......ssss...........sss..................sssssssssss....ssssss...........................ssssss..............
----------------------------------------------------------------------
Ran 110 tests in 0.185s

OK (skipped=30)
```