### PR TITLE
Fix flake8 error of importing modules at the top (E402)

### DIFF
--- a/devutils/makesdist
+++ b/devutils/makesdist
@@ -11,10 +11,10 @@ import subprocess
 import sys
 import tarfile
 
+from setup import FALLBACK_VERSION, versiondata
+
 BASEDIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(0, BASEDIR)
-
-from setup import FALLBACK_VERSION, versiondata
 
 timestamp = versiondata.getint("DEFAULT", "timestamp")
 

--- a/doc/manual/source/conf.py
+++ b/doc/manual/source/conf.py
@@ -16,6 +16,8 @@ import os
 import sys
 import time
 
+from setup import versiondata
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -61,7 +63,7 @@ copyright = "%Y, Brookhaven National Laboratory"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 sys.path.insert(0, os.path.abspath("../../.."))
-from setup import versiondata
+
 
 fullversion = versiondata.get("DEFAULT", "version")
 # The short X.Y version.

--- a/src/diffpy/srfit/equation/builder.py
+++ b/src/diffpy/srfit/equation/builder.py
@@ -93,9 +93,6 @@ __all__ = [
 # right-side over its arguments. This results in an array of BaseBuilder
 # instances, not an BaseBuilder that contains an array.
 
-_builders = {}
-
-
 import inspect
 import numbers
 
@@ -105,6 +102,8 @@ import six
 import diffpy.srfit.equation.literals as literals
 from diffpy.srfit.equation.equationmod import Equation
 from diffpy.srfit.equation.literals.literal import Literal
+
+_builders = {}
 
 
 class EquationFactory(object):
@@ -365,16 +364,9 @@ class EquationFactory(object):
         # generated.
         for tok in set(args):
             # Move genuine varibles to the eqargs dictionary
-            if (
-                # Check registered builders
-                tok in self.builders
-                or
-                # Check symbols
-                tok in EquationFactory.symbols
-                or
-                # Check ignored characters
-                tok in EquationFactory.ignore
-            ):
+            if (tok in self.builders or  # Check registered builders
+                tok in EquationFactory.symbols or  # Check symbols
+                tok in EquationFactory.ignore):  # Check ignored characters
                 args.remove(tok)
 
         return args


### PR DESCRIPTION
Test passes

```
imac@imacs-iMac diffpy.srfit % python -m diffpy.srfit.tests.run
WARNING:diffpy.srfit.tests:No module named 'sas', SaS tests skipped.
WARNING:diffpy.srfit.tests:Cannot import diffpy.structure, Structure tests skipped.
WARNING:diffpy.srfit.tests:Cannot import pyobjcryst, pyobjcryst tests skipped.
WARNING:diffpy.srfit.tests:Cannot import diffpy.srreal, PDF tests skipped.
......ssss...........sss..................sssssssssss....ssssss...........................ssssss..............
----------------------------------------------------------------------
Ran 110 tests in 0.198s

OK (skipped=30)
```