### PR TITLE
Fix flake8 error of unambigous variable names and "not xxx in" expression (E741, E713)

### DIFF
--- a/doc/examples/npintensity.py
+++ b/doc/examples/npintensity.py
@@ -337,15 +337,15 @@ def plotResults(recipe):
     # All this should be pretty familiar by now.
     q = recipe.bucky.profile.x
 
-    I = recipe.bucky.profile.y
-    Icalc = recipe.bucky.profile.ycalc
+    intensity = recipe.bucky.profile.y
+    intensity_calc = recipe.bucky.profile.ycalc
     bkgd = recipe.bucky.evaluateEquation("bkgd")
-    diff = I - Icalc
+    diff = intensity - intensity_calc
 
     import pylab
 
-    pylab.plot(q, I, "ob", label="I(Q) Data")
-    pylab.plot(q, Icalc, "r-", label="I(Q) Fit")
+    pylab.plot(q, intensity, "ob", label="I(Q) Data")
+    pylab.plot(q, intensity_calc, "r-", label="I(Q) Fit")
     pylab.plot(q, diff, "g-", label="I(Q) diff")
     pylab.plot(q, bkgd, "c-", label="Bkgd. Fit")
     pylab.xlabel(r"$Q (\AA^{-1})$")

--- a/src/diffpy/srfit/equation/builder.py
+++ b/src/diffpy/srfit/equation/builder.py
@@ -363,9 +363,11 @@ class EquationFactory(object):
         # generated.
         for tok in set(args):
             # Move genuine varibles to the eqargs dictionary
-            if (tok in self.builders or  # Check registered builders
-                tok in EquationFactory.symbols or  # Check symbols
-                tok in EquationFactory.ignore):  # Check ignored characters
+            if (
+                tok in self.builders  # Check registered builders
+                or tok in EquationFactory.symbols  # Check symbols
+                or tok in EquationFactory.ignore  # Check ignored characters
+            ):
                 args.remove(tok)
 
         return args
@@ -665,7 +667,7 @@ def __wrapSrFitOperators():
         inspect.isclass(cls)
         and issubclass(cls, opmod.Operator)
         and not inspect.isabstract(cls)
-        and not cls in excluded_types
+        and cls not in excluded_types
     )
     # create OperatorBuilder objects
     for nm, opclass in inspect.getmembers(opmod, is_exported_type):

--- a/src/diffpy/srfit/equation/equationmod.py
+++ b/src/diffpy/srfit/equation/equationmod.py
@@ -125,7 +125,7 @@ class Equation(Operator):
         """Gives access to the Arguments as attributes."""
         # Avoid infinite loop on argdict lookup.
         argdict = object.__getattribute__(self, "argdict")
-        if not name in argdict:
+        if name not in argdict:
             raise AttributeError("No argument named '%s' here" % name)
         return argdict[name]
 

--- a/src/diffpy/srfit/equation/literals/operators.py
+++ b/src/diffpy/srfit/equation/literals/operators.py
@@ -123,7 +123,7 @@ class Operator(Literal, OperatorABC):
     def getValue(self):
         """Get or evaluate the value of the operator."""
         if self._value is None:
-            vals = [l.value for l in self.args]
+            vals = [arg.value for arg in self.args]
             self._value = self.operation(*vals)
         return self._value
 
@@ -136,8 +136,8 @@ class Operator(Literal, OperatorABC):
 
         # Check to see if I am a dependency of the literal.
         if hasattr(literal, "args"):
-            for l in literal.args:
-                self._loopCheck(l)
+            for arg in literal.args:
+                self._loopCheck(arg)
         return
 
 

--- a/src/diffpy/srfit/fitbase/fitresults.py
+++ b/src/diffpy/srfit/fitbase/fitresults.py
@@ -326,7 +326,7 @@ class FitResults(object):
 
         if not certain:
             error_message = "Some quantities invalid due to missing profile uncertainty"
-            if not error_message in self.messages:
+            if error_message not in self.messages:
                 self.messages.append(error_message)
 
         lines.extend(self.messages)

--- a/src/diffpy/srfit/util/argbinders.py
+++ b/src/diffpy/srfit/util/argbinders.py
@@ -19,7 +19,6 @@ Functions for binding arguments of callable objects.
 
 
 class bind2nd(object):
-
     """Freeze second argument of a callable object to a given constant."""
 
     def __init__(self, func, arg1):


### PR DESCRIPTION
Test passes 

```
imac@imacs-iMac diffpy.srfit % python -m diffpy.srfit.tests.run
WARNING:diffpy.srfit.tests:No module named 'sas', SaS tests skipped.
WARNING:diffpy.srfit.tests:Cannot import pyobjcryst, pyobjcryst tests skipped.
WARNING:diffpy.srfit.tests:Cannot import diffpy.srreal, PDF tests skipped.
......ssss................................sssssssssss....ssssss...........................sss..s..............
----------------------------------------------------------------------
Ran 110 tests in 0.195s

OK (skipped=25)
```