### PR TITLE
Address flake8 error lambda functions (E731)

### DIFF
--- a/src/diffpy/srfit/equation/builder.py
+++ b/src/diffpy/srfit/equation/builder.py
@@ -661,7 +661,7 @@ def __wrapSrFitOperators():
     opmod = literals.operators
     excluded_types = set((opmod.CustomOperator, opmod.UFuncOperator))
     # check if opmod member should be wrapped as OperatorBuilder
-    is_exported_type = lambda cls: (
+    is_exported_type = lambda cls: (  # noqa: E731
         inspect.isclass(cls)
         and issubclass(cls, opmod.Operator)
         and not inspect.isabstract(cls)

--- a/src/diffpy/srfit/fitbase/fithook.py
+++ b/src/diffpy/srfit/fitbase/fithook.py
@@ -150,7 +150,7 @@ class PrintFitHook(FitHook):
             print("Variables")
             vnames = recipe.getNames()
             vals = recipe.getValues()
-            byname = lambda nv: sortKeyForNumericString(nv[0])
+            byname = lambda nv: sortKeyForNumericString(nv[0])  # noqa: E731
             items = sorted(zip(vnames, vals), key=byname)
             for name, val in items:
                 print("  %s = %f" % (name, val))

--- a/src/diffpy/srfit/fitbase/recipeorganizer.py
+++ b/src/diffpy/srfit/fitbase/recipeorganizer.py
@@ -730,7 +730,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
             self.unconstrain(*self._constraints)
 
         if recurse:
-            f = lambda m: hasattr(m, "clearConstraints")
+            f = lambda m: hasattr(m, "clearConstraints")  # noqa: E731
             for m in filter(f, self._iterManaged()):
                 m.clearConstraints(recurse)
         return
@@ -813,7 +813,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
         self.unrestrain(*self._restraints)
 
         if recurse:
-            f = lambda m: hasattr(m, "clearRestraints")
+            f = lambda m: hasattr(m, "clearRestraints")  # noqa: E731
             for m in filter(f, self._iterManaged()):
                 m.clearRestraints(recurse)
         return
@@ -822,7 +822,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
         """Get the constrained Parameters for this and managed sub-objects."""
         constraints = {}
         if recurse:
-            f = lambda m: hasattr(m, "_getConstraints")
+            f = lambda m: hasattr(m, "_getConstraints")  # noqa: E731
             for m in filter(f, self._iterManaged()):
                 constraints.update(m._getConstraints(recurse))
 
@@ -837,7 +837,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
         """
         restraints = set(self._restraints)
         if recurse:
-            f = lambda m: hasattr(m, "_getRestraints")
+            f = lambda m: hasattr(m, "_getRestraints")  # noqa: E731
             for m in filter(f, self._iterManaged()):
                 restraints.update(m._getRestraints(recurse))
 
@@ -948,7 +948,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
             the screen width.  Do not trim when negative or 0.
         """
         regexp = re.compile(pattern)
-        pmatch = lambda s: (len(s.split(None, 1)) < 2 or regexp.search(s.split(None, 1)[0]))
+        pmatch = lambda s: (len(s.split(None, 1)) < 2 or regexp.search(s.split(None, 1)[0]))  # noqa: E731
         # Show sub objects and their parameters
         lines = []
         tlines = self._formatManaged()

--- a/src/diffpy/srfit/pdf/characteristicfunctions.py
+++ b/src/diffpy/srfit/pdf/characteristicfunctions.py
@@ -198,7 +198,7 @@ def lognormalSphericalCF(r, psize, psig):
     if psig <= 0:
         return sphericalCF(r, psize)
 
-    erfc = lambda x: 1.0 - erf(x)
+    erfc = lambda x: 1.0 - erf(x)  # noqa: E731
 
     sqrt2 = sqrt(2.0)
     s = sqrt(log(psig * psig / (1.0 * psize * psize) + 1))

--- a/src/diffpy/srfit/sas/prcalculator.py
+++ b/src/diffpy/srfit/sas/prcalculator.py
@@ -92,7 +92,7 @@ class PrCalculator(Calculator):
         self._invertor.y = iq
         self._invertor.err = diq
         c, c_cov = self._invertor.invert_optimize()
-        calculate_pr = lambda x: self._invertor.pr(c, x)
+        calculate_pr = lambda x: self._invertor.pr(c, x)  # noqa: E731
         pr = map(calculate_pr, r)
 
         pr = numpy.array(pr)

--- a/src/diffpy/srfit/tests/testbuilder.py
+++ b/src/diffpy/srfit/tests/testbuilder.py
@@ -157,7 +157,7 @@ class TestBuilder(unittest.TestCase):
         eq.x.setValue(x)
         eq.B.setValue(B)
         eq.C.setValue(C)
-        f = lambda A, x, B, C: A * sin(0.5 * x) + divide(B, C)
+        f = lambda A, x, B, C: A * sin(0.5 * x) + divide(B, C)  # noqa: E731
         self.assertTrue(array_equal(eq(), f(A, x, B, C)))
 
         # Make sure that the arguments of eq are listed in the order in which
@@ -170,7 +170,7 @@ class TestBuilder(unittest.TestCase):
         sigma = 0.1
         eq.x.setValue(x)
         eq.sigma.setValue(sigma)
-        f = lambda x, sigma: sqrt(e ** (-0.5 * (x / sigma) ** 2))
+        f = lambda x, sigma: sqrt(e ** (-0.5 * (x / sigma) ** 2))  # noqa: E731
         self.assertTrue(numpy.allclose(eq(), f(x, sigma)))
 
         self.assertEqual(eq.args, [eq.x, eq.sigma])
@@ -246,7 +246,7 @@ class TestBuilder(unittest.TestCase):
         sigma = builder.ArgumentBuilder(name="sigma", value=0.1)
         beq = sqrt(e ** (-0.5 * (x / sigma) ** 2))
         eq = beq.getEquation()
-        f = lambda x, sigma: sqrt(e ** (-0.5 * (x / sigma) ** 2))
+        f = lambda x, sigma: sqrt(e ** (-0.5 * (x / sigma) ** 2))  # noqa: E731
         self.assertTrue(numpy.allclose(eq(), numpy.sqrt(e ** (-0.5 * (_x / 0.1) ** 2))))
 
         # Equation with Equation

--- a/src/diffpy/srfit/tests/testcontribution.py
+++ b/src/diffpy/srfit/tests/testcontribution.py
@@ -270,7 +270,7 @@ class TestContribution(unittest.TestCase):
     def test_registerFunction(self):
         """Ensure registered function works after second setEquation call."""
         fc = self.fitcontribution
-        fsquare = lambda x: x**2
+        fsquare = lambda x: x**2  # noqa: E731
         fc.registerFunction(fsquare, name="fsquare")
         fc.setEquation("fsquare")
         fc.x.setValue(5)


### PR DESCRIPTION
Tests pass:

```
imac@imacs-iMac diffpy.srfit % python -m diffpy.srfit.tests.run
WARNING:diffpy.srfit.tests:No module named 'sas', SaS tests skipped.
WARNING:diffpy.srfit.tests:Cannot import pyobjcryst, pyobjcryst tests skipped.
WARNING:diffpy.srfit.tests:Cannot import diffpy.srreal, PDF tests skipped.
......ssss................................sssssssssss....ssssss...........................sss..s..............
----------------------------------------------------------------------
Ran 110 tests in 0.170s

OK (skipped=25)
```