### PR TITLE
Fix flake8 error lambda functions (E731) with direct substitution 

### DIFF
--- a/src/diffpy/srfit/fitbase/fithook.py
+++ b/src/diffpy/srfit/fitbase/fithook.py
@@ -150,8 +150,7 @@ class PrintFitHook(FitHook):
             print("Variables")
             vnames = recipe.getNames()
             vals = recipe.getValues()
-            byname = lambda nv: sortKeyForNumericString(nv[0])
-            items = sorted(zip(vnames, vals), key=byname)
+            items = sorted(zip(vnames, vals), key=lambda nv: sortKeyForNumericString(nv[0]))
             for name, val in items:
                 print("  %s = %f" % (name, val))
         return

--- a/src/diffpy/srfit/fitbase/recipeorganizer.py
+++ b/src/diffpy/srfit/fitbase/recipeorganizer.py
@@ -730,8 +730,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
             self.unconstrain(*self._constraints)
 
         if recurse:
-            f = lambda m: hasattr(m, "clearConstraints")
-            for m in filter(f, self._iterManaged()):
+            for m in filter(lambda m: hasattr(m, "clearConstraints"), self._iterManaged()):
                 m.clearConstraints(recurse)
         return
 
@@ -813,8 +812,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
         self.unrestrain(*self._restraints)
 
         if recurse:
-            f = lambda m: hasattr(m, "clearRestraints")
-            for m in filter(f, self._iterManaged()):
+            for m in filter(lambda m: hasattr(m, "clearRestraints"), self._iterManaged()):
                 m.clearRestraints(recurse)
         return
 
@@ -822,8 +820,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
         """Get the constrained Parameters for this and managed sub-objects."""
         constraints = {}
         if recurse:
-            f = lambda m: hasattr(m, "_getConstraints")
-            for m in filter(f, self._iterManaged()):
+            for m in filter(lambda m: hasattr(m, "_getConstraints"), self._iterManaged()):
                 constraints.update(m._getConstraints(recurse))
 
         constraints.update(self._constraints)
@@ -837,8 +834,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
         """
         restraints = set(self._restraints)
         if recurse:
-            f = lambda m: hasattr(m, "_getRestraints")
-            for m in filter(f, self._iterManaged()):
+            for m in filter(lambda m: hasattr(m, "_getRestraints"), self._iterManaged()):
                 restraints.update(m._getRestraints(recurse))
 
         return restraints

--- a/src/diffpy/srfit/tests/testbuilder.py
+++ b/src/diffpy/srfit/tests/testbuilder.py
@@ -157,7 +157,7 @@ class TestBuilder(unittest.TestCase):
         eq.x.setValue(x)
         eq.B.setValue(B)
         eq.C.setValue(C)
-        f = lambda A, x, B, C: A * sin(0.5 * x) + divide(B, C)
+        f = lambda A, x, B, C: A * sin(0.5 * x) + divide(B, C)  # noqa: E731
         self.assertTrue(array_equal(eq(), f(A, x, B, C)))
 
         # Make sure that the arguments of eq are listed in the order in which
@@ -170,7 +170,7 @@ class TestBuilder(unittest.TestCase):
         sigma = 0.1
         eq.x.setValue(x)
         eq.sigma.setValue(sigma)
-        f = lambda x, sigma: sqrt(e ** (-0.5 * (x / sigma) ** 2))
+        f = lambda x, sigma: sqrt(e ** (-0.5 * (x / sigma) ** 2))  # noqa: E731
         self.assertTrue(numpy.allclose(eq(), f(x, sigma)))
 
         self.assertEqual(eq.args, [eq.x, eq.sigma])
@@ -246,7 +246,7 @@ class TestBuilder(unittest.TestCase):
         sigma = builder.ArgumentBuilder(name="sigma", value=0.1)
         beq = sqrt(e ** (-0.5 * (x / sigma) ** 2))
         eq = beq.getEquation()
-        f = lambda x, sigma: sqrt(e ** (-0.5 * (x / sigma) ** 2))
+        f = lambda x, sigma: sqrt(e ** (-0.5 * (x / sigma) ** 2))  # noqa: E731
         self.assertTrue(numpy.allclose(eq(), numpy.sqrt(e ** (-0.5 * (_x / 0.1) ** 2))))
 
         # Equation with Equation


### PR DESCRIPTION
Reflecting the comments from https://github.com/diffpy/diffpy.srfit/pull/78

Test passes:

```
WARNING:diffpy.srfit.tests:No module named 'sas', SaS tests skipped.
WARNING:diffpy.srfit.tests:Cannot import pyobjcryst, pyobjcryst tests skipped.
WARNING:diffpy.srfit.tests:Cannot import diffpy.srreal, PDF tests skipped.
......ssss................................sssssssssss....ssssss...........................sss..s..............
----------------------------------------------------------------------
Ran 110 tests in 0.187s

OK (skipped=25)
```