### PR TITLE
Fix flake8 error lambda functions (E731) with private function for pattern matching

### DIFF
--- a/src/diffpy/srfit/fitbase/recipeorganizer.py
+++ b/src/diffpy/srfit/fitbase/recipeorganizer.py
@@ -933,7 +933,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
         rlines.sort(key=numstr)
         return rlines
 
-    def _get_pmatch(self, s):
+    def _matchPattern(self, s):
         return len(s.split(None, 1)) < 2 or self._regexp.search(s.split(None, 1)[0])
     
     def show(self, pattern="", textwidth=78):
@@ -957,7 +957,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
         tlines = self._formatManaged()
         if tlines:
             lines.extend(["Parameters", _DASHEDLINE])
-            linesok = filter(self._get_pmatch, tlines)
+            linesok = filter(self._matchPattern, tlines)
             lastnotblank = False
             # squeeze repeated blank lines
             for lastnotblank, g in groupby(linesok, bool):
@@ -983,7 +983,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
             if lines:
                 lines.append("")
             lines.extend(["Restraints", _DASHEDLINE])
-            lines.extend(filter(self._get_pmatch, tlines))
+            lines.extend(filter(self._matchPattern, tlines))
 
         # Determine effective text width tw.
         tw = textwidth if (textwidth is not None and textwidth > 0) else None

--- a/src/diffpy/srfit/fitbase/recipeorganizer.py
+++ b/src/diffpy/srfit/fitbase/recipeorganizer.py
@@ -933,6 +933,9 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
         rlines.sort(key=numstr)
         return rlines
 
+    def _get_pmatch(self, s):
+        return len(s.split(None, 1)) < 2 or self._regexp.search(s.split(None, 1)[0])
+    
     def show(self, pattern="", textwidth=78):
         """Show the configuration hierarchy on the screen.
 
@@ -947,14 +950,14 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
             Trim formatted lines at this text width to avoid folding at
             the screen width.  Do not trim when negative or 0.
         """
-        regexp = re.compile(pattern)
-        pmatch = lambda s: (len(s.split(None, 1)) < 2 or regexp.search(s.split(None, 1)[0]))
+        self._regexp = re.compile(pattern)
+
         # Show sub objects and their parameters
         lines = []
         tlines = self._formatManaged()
         if tlines:
             lines.extend(["Parameters", _DASHEDLINE])
-            linesok = filter(pmatch, tlines)
+            linesok = filter(self._get_pmatch, tlines)
             lastnotblank = False
             # squeeze repeated blank lines
             for lastnotblank, g in groupby(linesok, bool):
@@ -965,7 +968,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
 
         # FIXME - parameter names in equations not particularly informative
         # Show constraints
-        cmatch = regexp.search
+        cmatch = self._regexp.search
         tlines = self._formatConstraints()
         if tlines:
             if lines:
@@ -980,7 +983,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
             if lines:
                 lines.append("")
             lines.extend(["Restraints", _DASHEDLINE])
-            lines.extend(filter(pmatch, tlines))
+            lines.extend(filter(self._get_pmatch, tlines))
 
         # Determine effective text width tw.
         tw = textwidth if (textwidth is not None and textwidth > 0) else None

--- a/src/diffpy/srfit/fitbase/recipeorganizer.py
+++ b/src/diffpy/srfit/fitbase/recipeorganizer.py
@@ -933,7 +933,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
         rlines.sort(key=numstr)
         return rlines
 
-    def _matchPattern(self, s):
+    def _is_single_or_matches_pattern(self, s):
         return len(s.split(None, 1)) < 2 or self._regexp.search(s.split(None, 1)[0])
     
     def show(self, pattern="", textwidth=78):
@@ -957,7 +957,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
         tlines = self._formatManaged()
         if tlines:
             lines.extend(["Parameters", _DASHEDLINE])
-            linesok = filter(self._matchPattern, tlines)
+            linesok = filter(self._is_single_or_matches_pattern, tlines)
             lastnotblank = False
             # squeeze repeated blank lines
             for lastnotblank, g in groupby(linesok, bool):
@@ -983,7 +983,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
             if lines:
                 lines.append("")
             lines.extend(["Restraints", _DASHEDLINE])
-            lines.extend(filter(self._matchPattern, tlines))
+            lines.extend(filter(self._is_single_or_matches_pattern, tlines))
 
         # Determine effective text width tw.
         tw = textwidth if (textwidth is not None and textwidth > 0) else None


### PR DESCRIPTION
`camelCase` is used here.

Addressing the following https://github.com/diffpy/diffpy.srfit/pull/78/files#r1724308313

<img width="789" alt="Screenshot 2024-08-21 at 6 24 15 PM" src="https://github.com/user-attachments/assets/ce94a422-4cb6-4676-9697-35865cd03ca3">


Tests pass

```
WARNING:diffpy.srfit.tests:No module named 'sas', SaS tests skipped.
WARNING:diffpy.srfit.tests:Cannot import pyobjcryst, pyobjcryst tests skipped.
WARNING:diffpy.srfit.tests:Cannot import diffpy.srreal, PDF tests skipped.
......ssss................................sssssssssss....ssssss...........................sss..s..............
----------------------------------------------------------------------
Ran 110 tests in 0.254s
```