### PR TITLE
Fix flake8 error lambda functions (E731) by importing erfc from scipy

### DIFF
--- a/src/diffpy/srfit/pdf/characteristicfunctions.py
+++ b/src/diffpy/srfit/pdf/characteristicfunctions.py
@@ -41,7 +41,7 @@ from numpy import arctan as atan
 from numpy import arctanh as atanh
 from numpy import ceil, exp, log, log2, pi, sign, sqrt
 from numpy.fft import fftfreq, ifft
-from scipy.special import erf
+from scipy.special import erfc
 
 from diffpy.srfit.fitbase.calculator import Calculator
 
@@ -197,8 +197,6 @@ def lognormalSphericalCF(r, psize, psig):
         return numpy.zeros_like(r)
     if psig <= 0:
         return sphericalCF(r, psize)
-
-    erfc = lambda x: 1.0 - erf(x)
 
     sqrt2 = sqrt(2.0)
     s = sqrt(log(psig * psig / (1.0 * psize * psize) + 1))


### PR DESCRIPTION


```
imac@imacs-iMac diffpy.srfit % python -m diffpy.srfit.tests.run
WARNING:diffpy.srfit.tests:No module named 'sas', SaS tests skipped.
WARNING:diffpy.srfit.tests:Cannot import pyobjcryst, pyobjcryst tests skipped.
WARNING:diffpy.srfit.tests:Cannot import diffpy.srreal, PDF tests skipped.
......ssss................................sssssssssss....ssssss...........................sss..s..............
----------------------------------------------------------------------
Ran 110 tests in 0.213s

OK (skipped=25)
```