### PR TITLE
Fix flake8 with noqa: E731

### DIFF
--- a/src/diffpy/srfit/fitbase/recipeorganizer.py
+++ b/src/diffpy/srfit/fitbase/recipeorganizer.py
@@ -944,7 +944,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
             the screen width.  Do not trim when negative or 0.
         """
         regexp = re.compile(pattern)
-        pmatch = lambda s: (len(s.split(None, 1)) < 2 or regexp.search(s.split(None, 1)[0]))
+        pmatch = lambda s: (len(s.split(None, 1)) < 2 or regexp.search(s.split(None, 1)[0]))  # noqa: E731
         # Show sub objects and their parameters
         lines = []
         tlines = self._formatManaged()


### PR DESCRIPTION
To expedite cookiecutting, I have added `noqa: E731`.

All flake8 errors have been resolved. 

I created an issue to re-address it - https://github.com/diffpy/diffpy.srfit/issues/83