### PR TITLE
feat: use `ValueError` instead of `TypeError` for failed `Operator.operation`

### DIFF
--- a/news/use-valuerror.rst
+++ b/news/use-valuerror.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Use ``ValueError`` instead of ``TypeError`` for failed ``Operator.operation``.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/srfit/equation/literals/operators.py
+++ b/src/diffpy/srfit/equation/literals/operators.py
@@ -123,7 +123,13 @@ class Operator(Literal, OperatorABC):
         """Get or evaluate the value of the operator."""
         if self._value is None:
             vals = [arg.value for arg in self.args]
-            self._value = self.operation(*vals)
+            try:
+                self._value = self.operation(*vals)
+            except Exception as e:
+                raise ValueError(
+                    "Error evaluating operator '%s' with arguments %s : %s"
+                    % (self, vals, e)
+                )
         return self._value
 
     value = property(lambda self: self.getValue())

--- a/tests/test_literals.py
+++ b/tests/test_literals.py
@@ -115,7 +115,7 @@ class TestCustomOperator(unittest.TestCase):
         """Test adding a literal to an operator node."""
         op = self.op
 
-        self.assertRaises(TypeError, op.getValue)
+        self.assertRaises(ValueError, op.getValue)
         op._value = 1
         self.assertEqual(op.getValue(), 1)
 
@@ -124,7 +124,7 @@ class TestCustomOperator(unittest.TestCase):
         b = literals.Argument(name="b", value=0)
 
         op.addLiteral(a)
-        self.assertRaises(TypeError, op.getValue)
+        self.assertRaises(ValueError, op.getValue)
 
         op.addLiteral(b)
         self.assertAlmostEqual(0, op.value)

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -207,7 +207,7 @@ class TestSwapper:
         assert plus2.hasObserver(mult._flush)
 
         # plus2 has no arguments yet. Verify this.
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             mult.getValue()
         # Add the arguments to plus2.
         plus2.addLiteral(v4)


### PR DESCRIPTION
### What problem does this PR address?

Closes #72 

Use `ValueError` instead of `TypeError` for incorrect calculations.

### What should the reviewer(s) do?

Please check the modifications.