### PR TITLE
chore: sync conf.py extensions with docs dependencies listed in requirements folder

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_rtd_theme",
     "sphinx_copybutton",
-    "m2r2",
+    "m2r",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -302,7 +302,7 @@ texinfo_documents = [
         "diffpy.srfit Documentation",
         ab_authors,
         "diffpy.srfit",
-        "One line description of project.",
+        "Configurable code for solving atomic structures.",
         "Miscellaneous",
     ),
 ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_rtd_theme",
     "sphinx_copybutton",
-    "m2r",
+    "m2r2",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/news/update-docs-dependency.rst
+++ b/news/update-docs-dependency.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news added: Trivial change to conf.py
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -2,4 +2,4 @@ sphinx
 sphinx_rtd_theme
 sphinx-copybutton
 doctr
-m2r
+m2r2


### PR DESCRIPTION
### What problem does this PR address?

<!-- Provide a brief overview and link to the issue. Attach outputs, including screenshots (before/after), if helpful for the reviewer. -->
In `requirements/docs.txt`, `m2r` is installed as a dependency when the docs are being built. However, `docs/source/conf.py` lists `m2r2` instead of `m2r` as one of the extensions being used by Sphinx to build the docs. This causes an error when building the docs. This PR fixes this error by updating the `conf.py` extensions so it is in sync with the dependencies listed in `requirements/docs.txt`.

### What should the reviewer(s) do?

<!-- Merge the code, provide feedback, initiate a discussion, etc. -->
Please review and merge.

<!--
Use the following checklist items when applicable (select only what applies):
- [ ] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [ ] A tracking issue or plan to update documentation exists.
- [ ] This PR affects internal functionality only (no user-facing change).
-->
