### PR TITLE
deprecate: `pushFitHook`, `popFitHook`, `getFitHook`, `clearFitHook`, and `setWeight` in `FitRecipe`

### DIFF
--- a/docs/examples/coreshellnp.py
+++ b/docs/examples/coreshellnp.py
@@ -169,7 +169,7 @@ def main():
     recipe = makeRecipe(stru1, stru2, data)
     from diffpy.srfit.fitbase.fithook import PlotFitHook
 
-    recipe.pushFitHook(PlotFitHook())
+    recipe.push_fit_hook(PlotFitHook())
     recipe.fithooks[0].verbose = 3
 
     # Optimize - we do this in steps to help convergence

--- a/docs/examples/npintensityII.py
+++ b/docs/examples/npintensityII.py
@@ -248,17 +248,17 @@ def main():
     # fit.
     recipe.fix("all")
     recipe.free("bcoeffs1")
-    recipe.setWeight(recipe.bucky2, 0)
+    recipe.set_weight(recipe.bucky2, 0)
     scipyOptimize(recipe)
     # Now do the same for the second background
     recipe.fix("all")
     recipe.free("bcoeffs1")
-    recipe.setWeight(recipe.bucky2, 1)
-    recipe.setWeight(recipe.bucky1, 0)
+    recipe.set_weight(recipe.bucky2, 1)
+    recipe.set_weight(recipe.bucky1, 0)
     scipyOptimize(recipe)
     # Now refine everything with the structure parameters included
     recipe.free("all")
-    recipe.setWeight(recipe.bucky1, 1)
+    recipe.set_weight(recipe.bucky1, 1)
     scipyOptimize(recipe)
 
     # Generate and print the FitResults

--- a/docs/examples/nppdfsas.py
+++ b/docs/examples/nppdfsas.py
@@ -122,7 +122,7 @@ def fitRecipe(recipe):
     """We refine in stages to help the refinement converge."""
 
     # Tune SAS.
-    recipe.setWeight(recipe.pdf, 0)
+    recipe.set_weight(recipe.pdf, 0)
     recipe.fix("all")
     recipe.free("radius_a", "radius_b", iqscale=1e8)
     recipe.constrain("radius_b", "radius_a")
@@ -130,15 +130,15 @@ def fitRecipe(recipe):
     recipe.unconstrain("radius_b")
 
     # Tune PDF
-    recipe.setWeight(recipe.pdf, 1)
-    recipe.setWeight(recipe.sas, 0)
+    recipe.set_weight(recipe.pdf, 1)
+    recipe.set_weight(recipe.sas, 0)
     recipe.fix("all")
     recipe.free("a", "Biso_0", "scale", "delta2")
     scipyOptimize(recipe)
 
     # Tune all
-    recipe.setWeight(recipe.pdf, 1)
-    recipe.setWeight(recipe.sas, 1)
+    recipe.set_weight(recipe.pdf, 1)
+    recipe.set_weight(recipe.sas, 1)
     recipe.free("all")
     scipyOptimize(recipe)
 

--- a/docs/source/extending.rst
+++ b/docs/source/extending.rst
@@ -263,5 +263,5 @@ overload.
 * .. automethod:: FitHook.postcall
 
 To use a custom ``FitHook``, assign an instance to a ``FitRecipe`` using the
-``pushFitHook`` method. All ``FitHook`` instances held by a ``FitRecipe`` will
+``push_fit_hook`` method. All ``FitHook`` instances held by a ``FitRecipe`` will
 be used in sequence during a call to ``FitRecipe.residual``.

--- a/news/fithook-and-weights-dep.rst
+++ b/news/fithook-and-weights-dep.rst
@@ -1,0 +1,27 @@
+**Added:**
+
+* Added ``set_weight`` method to ``FitRecipe`` to replace ``setWeight``.
+* Added ``get_fit_hooks`` method to ``FitRecipe`` to replace ``getFitHooks``.
+* Added ``clear_fit_hooks`` method to ``FitRecipe`` to replace ``clearFitHooks``.
+* Added ``pop_fit_hook`` method to ``FitRecipe`` to replace ``popFitHook``.
+* Added ``push_fit_hook`` method to ``FitRecipe`` to replace ``pushFitHook``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* Deprecate ``setWeight``, ``getFitHooks``, ``clearFitHooks``, ``popFitHook``, and ``pushFitHook`` in ``FitRecipe`` for removal in 4.0.0.
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/fithook-and-weights-dep.rst
+++ b/news/fithook-and-weights-dep.rst
@@ -12,7 +12,11 @@
 
 **Deprecated:**
 
-* Deprecate ``setWeight``, ``getFitHooks``, ``clearFitHooks``, ``popFitHook``, and ``pushFitHook`` in ``FitRecipe`` for removal in 4.0.0.
+* Deprecated ``setWeight`` in ``FitRecipe`` for removal in 4.0.0.
+* Deprecated ``getFitHooks`` in ``FitRecipe`` for removal in 4.0.0.
+* Deprecated ``clearFitHooks`` in ``FitRecipe`` for removal in 4.0.0.
+* Deprecated ``popFitHook`` in ``FitRecipe`` for removal in 4.0.0.
+* Deprecated ``pushFitHook`` in ``FitRecipe`` for removal in 4.0.0.
 
 **Removed:**
 

--- a/src/diffpy/srfit/fitbase/fithook.py
+++ b/src/diffpy/srfit/fitbase/fithook.py
@@ -37,10 +37,10 @@ class FitHook(object):
     """Base class for inspecting the progress of a FitRecipe refinement.
 
     Can serve as a fithook for the FitRecipe class (see
-    FitRecipe.pushFitHook method.) The methods in this class are called
-    during the preparation of the FitRecipe for refinement, and during
-    the residual call. See the class methods for a description of their
-    purpose.
+    FitRecipe.push_fit_hook method.) The methods in this class are
+    called during the preparation of the FitRecipe for refinement, and
+    during the residual call. See the class methods for a description of
+    their purpose.
     """
 
     def reset(self, recipe):

--- a/src/diffpy/srfit/fitbase/fitrecipe.py
+++ b/src/diffpy/srfit/fitbase/fitrecipe.py
@@ -63,6 +63,14 @@ popfithook_dep_msg = build_deprecation_message(
     base, "popFitHook", "pop_fit_hook", removal_version
 )
 
+getfithooks_dep_msg = build_deprecation_message(
+    base, "getFitHooks", "get_fit_hooks", removal_version
+)
+
+clearfithooks_dep_msg = build_deprecation_message(
+    base, "clearFitHooks", "clear_fit_hooks", removal_version
+)
+
 
 class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
     """FitRecipe class.
@@ -264,13 +272,30 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
         self.pop_fit_hook(fithook, index)
         return
 
-    def getFitHooks(self):
+    def get_fit_hooks(self):
         """Get the sequence of FitHook instances."""
         return self.fithooks[:]
 
-    def clearFitHooks(self):
+    @deprecated(getfithooks_dep_msg)
+    def getFitHooks(self):
+        """This function has been deprecated and will be removed in version
+        4.0.0.
+
+        Please use diffpy.srfit.fitbase.FitRecipe.get_fit_hooks instead."""
+        return self.get_fit_hooks()
+
+    def clear_fit_hooks(self):
         """Clear the FitHook sequence."""
         del self.fithooks[:]
+        return
+
+    @deprecated(clearfithooks_dep_msg)
+    def clearFitHooks(self):
+        """This function has been deprecated and will be removed in version
+        4.0.0.
+
+        Please use diffpy.srfit.fitbase.FitRecipe.clear_fit_hooks instead."""
+        self.clear_fit_hooks()
         return
 
     def add_contribution(self, con, weight=1.0):

--- a/src/diffpy/srfit/fitbase/fitrecipe.py
+++ b/src/diffpy/srfit/fitbase/fitrecipe.py
@@ -254,6 +254,7 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
         self.fithook.remove(index)
         return
 
+    @deprecated(popfithook_dep_msg)
     def popFitHook(self, fithook=None, index=-1):
         """This function has been deprecated and will be removed in version
         4.0.0.

--- a/src/diffpy/srfit/fitbase/fitrecipe.py
+++ b/src/diffpy/srfit/fitbase/fitrecipe.py
@@ -71,6 +71,10 @@ clearfithooks_dep_msg = build_deprecation_message(
     base, "clearFitHooks", "clear_fit_hooks", removal_version
 )
 
+setweight_dep_msg = build_deprecation_message(
+    base, "setWeight", "set_weight", removal_version
+)
+
 
 class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
     """FitRecipe class.
@@ -326,10 +330,19 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
         self.add_contribution(con, weight)
         return
 
-    def setWeight(self, con, weight):
+    def set_weight(self, con, weight):
         """Set the weight of a FitContribution."""
         idx = list(self._contributions.values()).index(con)
         self._weights[idx] = weight
+        return
+
+    @deprecated(setweight_dep_msg)
+    def setWeight(self, con, weight):
+        """This function has been deprecated and will be removed in version
+        4.0.0.
+
+        Please use diffpy.srfit.fitbase.FitRecipe.set_weight instead."""
+        self.set_weight(con, weight)
         return
 
     def addParameterSet(self, parset):

--- a/src/diffpy/srfit/fitbase/fitrecipe.py
+++ b/src/diffpy/srfit/fitbase/fitrecipe.py
@@ -55,6 +55,10 @@ addcontrib_dep_msg = build_deprecation_message(
     base, "addContribution", "add_contribution", removal_version
 )
 
+pushfithook_dep_msg = build_deprecation_message(
+    base, "pushFitHook", "push_fit_hook", removal_version
+)
+
 
 class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
     """FitRecipe class.
@@ -191,7 +195,7 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
         }
         return
 
-    def pushFitHook(self, fithook, index=None):
+    def push_fit_hook(self, fithook, index=None):
         """Add a FitHook to be called within the residual method.
 
         The hook is an object for reporting updates, or more fundamentally,
@@ -212,6 +216,16 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
         self.fithooks.insert(index, fithook)
         # Make sure the added FitHook gets its reset method called.
         self._update_configuration()
+        return
+
+    @deprecated(pushfithook_dep_msg)
+    def pushFitHook(self, fithook, index=None):
+        """This function has been deprecated and will be removed in version
+        4.0.0.
+
+        Please use diffpy.srfit.fitbase.FitRecipe.push_fit_hook instead.
+        """
+        self.push_fit_hook(fithook, index)
         return
 
     def popFitHook(self, fithook=None, index=-1):

--- a/src/diffpy/srfit/fitbase/fitrecipe.py
+++ b/src/diffpy/srfit/fitbase/fitrecipe.py
@@ -59,6 +59,10 @@ pushfithook_dep_msg = build_deprecation_message(
     base, "pushFitHook", "push_fit_hook", removal_version
 )
 
+popfithook_dep_msg = build_deprecation_message(
+    base, "popFitHook", "pop_fit_hook", removal_version
+)
+
 
 class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
     """FitRecipe class.
@@ -228,7 +232,7 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
         self.push_fit_hook(fithook, index)
         return
 
-    def popFitHook(self, fithook=None, index=-1):
+    def pop_fit_hook(self, fithook=None, index=-1):
         """Remove a FitHook by index or reference.
 
         Attributes
@@ -248,6 +252,15 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
             self.fithooks.remove(fithook)
             return
         self.fithook.remove(index)
+        return
+
+    def popFitHook(self, fithook=None, index=-1):
+        """This function has been deprecated and will be removed in version
+        4.0.0.
+
+        Please use diffpy.srfit.fitbase.FitRecipe.pop_fit_hook instead.
+        """
+        self.pop_fit_hook(fithook, index)
         return
 
     def getFitHooks(self):

--- a/tests/test_fitrecipe.py
+++ b/tests/test_fitrecipe.py
@@ -320,7 +320,7 @@ def test_add_contribution(capturestdout):
 
     recipe.addVar(fitcontribution.c)
     recipe.restrain("c", lb=5)
-    (pfh,) = recipe.getFitHooks()
+    (pfh,) = recipe.get_fit_hooks()
     out = capturestdout(recipe.scalarResidual)
     assert "" == out
     pfh.verbose = 1


### PR DESCRIPTION
Did all these simultaneously because they are relatively easy deprecations. 