### PR TITLE
Deprecate: Deprecate `setResidualEquation` and `getResidualEquation` in `Fitcontribution`

### DIFF
--- a/docs/examples/crystalpdfall.py
+++ b/docs/examples/crystalpdfall.py
@@ -97,10 +97,10 @@ def makeRecipe(
     xcontribution_sini.set_equation("scale * (xG_sini_ni +  xG_sini_si)")
 
     # As explained in another example, we want to minimize using Rw^2.
-    xcontribution_ni.setResidualEquation("resv")
-    xcontribution_si.setResidualEquation("resv")
-    ncontribution_ni.setResidualEquation("resv")
-    xcontribution_sini.setResidualEquation("resv")
+    xcontribution_ni.set_residual_equation("resv")
+    xcontribution_si.set_residual_equation("resv")
+    ncontribution_ni.set_residual_equation("resv")
+    xcontribution_sini.set_residual_equation("resv")
 
     # Make the FitRecipe and add the FitContributions.
     recipe = FitRecipe()

--- a/docs/examples/crystalpdftwodata.py
+++ b/docs/examples/crystalpdftwodata.py
@@ -105,8 +105,8 @@ def makeRecipe(ciffile, xdatname, ndatname):
     # The contribution's residual can be either chi^2, Rw^2, or custom crafted.
     # In this case, we should minimize Rw^2 of each contribution so that each
     # one can contribute roughly equally to the fit.
-    xcontribution.setResidualEquation("resv")
-    ncontribution.setResidualEquation("resv")
+    xcontribution.set_residual_equation("resv")
+    ncontribution.set_residual_equation("resv")
 
     # Make the FitRecipe and add the FitContributions.
     recipe = FitRecipe()

--- a/docs/examples/ellipsoidsas.py
+++ b/docs/examples/ellipsoidsas.py
@@ -64,7 +64,7 @@ def makeRecipe(datname):
     # higher-Q information remains significant. There are no I(Q) uncertainty
     # values with the data, so we do not need to worry about the effect this
     # will have on the estimated parameter uncertainties.
-    contribution.setResidualEquation("log(eq) - log(y)")
+    contribution.set_residual_equation("log(eq) - log(y)")
 
     # Make the FitRecipe and add the FitContribution.
     recipe = FitRecipe()

--- a/docs/examples/nppdfsas.py
+++ b/docs/examples/nppdfsas.py
@@ -59,7 +59,7 @@ def makeRecipe(ciffile, grdata, iqdata):
     stru = loadCrystal(ciffile)
     pdfgenerator.setStructure(stru)
     pdfcontribution.add_profile_generator(pdfgenerator)
-    pdfcontribution.setResidualEquation("resv")
+    pdfcontribution.set_residual_equation("resv")
 
     # Create a SAS contribution as well. We assume the nanoparticle is roughly
     # elliptical.
@@ -78,7 +78,7 @@ def makeRecipe(ciffile, grdata, iqdata):
     model = EllipsoidModel()
     sasgenerator = SASGenerator("generator", model)
     sascontribution.add_profile_generator(sasgenerator)
-    sascontribution.setResidualEquation("resv")
+    sascontribution.set_residual_equation("resv")
 
     # Now we set up a characteristic function calculator that depends on the
     # sas model.

--- a/news/fitcontrib-dep-final.rst
+++ b/news/fitcontrib-dep-final.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Added ``get_residual_equation`` method to ``FitContribution``.
+* Added ``set_residual_equation`` method to ``FitContribution``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* Deprecated ``getResidualEquation`` method of ``FitContribution``.
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/fitcontrib-dep-final.rst
+++ b/news/fitcontrib-dep-final.rst
@@ -9,7 +9,8 @@
 
 **Deprecated:**
 
-* Deprecated ``getResidualEquation`` method of ``FitContribution``.
+* Deprecated ``getResidualEquation`` method of ``FitContribution`` for removal in 4.0.0.
+* Deprecated ``setResidualEquation`` method of ``FitContribution`` for removal in 4.0.0.
 
 **Removed:**
 

--- a/src/diffpy/srfit/fitbase/fitcontribution.py
+++ b/src/diffpy/srfit/fitbase/fitcontribution.py
@@ -70,6 +70,13 @@ setresidualequation_dep_msg = build_deprecation_message(
     removal_version,
 )
 
+getresidualequation_dep_msg = build_deprecation_message(
+    base,
+    "getResidualEquation",
+    "get_residual_equation",
+    removal_version,
+)
+
 
 class FitContribution(ParameterSet):
     """FitContribution class.
@@ -397,7 +404,7 @@ class FitContribution(ParameterSet):
         self.set_residual_equation(eqstr)
         return
 
-    def getResidualEquation(self):
+    def get_residual_equation(self):
         """Get math expression string for the active residual equation.
 
         Return normalized math formula or an empty string if residual
@@ -409,6 +416,18 @@ class FitContribution(ParameterSet):
         if self._reseq is not None:
             rv = getExpression(self._reseq, eqskip="eq$")
         return rv
+
+    @deprecated(getresidualequation_dep_msg)
+    def getResidualEquation(self):
+        """This function has been deprecated and will be removed in version
+        4.0.0.
+
+        Please use
+        diffpy.srfit.fitbase.FitContribution.get_residual_equation
+        instead.
+        """
+
+        return self.get_residual_equation()
 
     def residual(self):
         """Calculate the residual for this fitcontribution.

--- a/src/diffpy/srfit/fitbase/fitcontribution.py
+++ b/src/diffpy/srfit/fitbase/fitcontribution.py
@@ -63,6 +63,13 @@ getequation_dep_msg = build_deprecation_message(
     removal_version,
 )
 
+setresidualequation_dep_msg = build_deprecation_message(
+    base,
+    "setResidualEquation",
+    "set_residual_equation",
+    removal_version,
+)
+
 
 class FitContribution(ParameterSet):
     """FitContribution class.
@@ -186,7 +193,7 @@ class FitContribution(ParameterSet):
 
         # If we have _eq, but not _reseq, set the residual
         if self._eq is not None and self._reseq is None:
-            self.setResidualEquation("chiv")
+            self.set_residual_equation("chiv")
 
         return
 
@@ -262,7 +269,7 @@ class FitContribution(ParameterSet):
 
         This sets the equation that will be used when generating the residual
         for this FitContribution.  The equation will be usable within
-        setResidualEquation as "eq", and it takes no arguments.
+        set_residual_equation as "eq", and it takes no arguments.
 
         Attributes
         ----------
@@ -296,7 +303,7 @@ class FitContribution(ParameterSet):
 
         # Set the residual if we need to
         if self.profile is not None and self._reseq is None:
-            self.setResidualEquation("chiv")
+            self.set_residual_equation("chiv")
 
         return
 
@@ -334,7 +341,7 @@ class FitContribution(ParameterSet):
         """
         return self.get_equation()
 
-    def setResidualEquation(self, eqstr):
+    def set_residual_equation(self, eqstr):
         """Set the residual equation for the FitContribution.
 
         Attributes
@@ -378,6 +385,18 @@ class FitContribution(ParameterSet):
 
         return
 
+    @deprecated(setresidualequation_dep_msg)
+    def setResidualEquation(self, eqstr):
+        """This function has been deprecated and will be removed in version
+        4.0.0.
+
+        Please use
+        diffpy.srfit.fitbase.FitContribution.set_residual_equation
+        instead.
+        """
+        self.set_residual_equation(eqstr)
+        return
+
     def getResidualEquation(self):
         """Get math expression string for the active residual equation.
 
@@ -402,7 +421,7 @@ class FitContribution(ParameterSet):
         chiv = (eq() - self.profile.y) / self.profile.dy
         The value that is optimized is dot(chiv, chiv).
 
-        The residual equation can be changed with the setResidualEquation
+        The residual equation can be changed with the set_residual_equation
         method.
         """
         # Assign the calculated profile

--- a/src/diffpy/srfit/fitbase/simplerecipe.py
+++ b/src/diffpy/srfit/fitbase/simplerecipe.py
@@ -288,8 +288,8 @@ class SimpleRecipe(FitRecipe):
         """Set the profile equation for the FitContribution.
 
         This sets the equation that will be used when generating the residual.
-        The equation will be usable within setResidualEquation as "eq", and it
-        takes no arguments.
+        The equation will be usable within set_residual_equation as "eq", and
+        it takes no arguments.
 
         Attributes
         ----------

--- a/src/diffpy/srfit/fitbase/simplerecipe.py
+++ b/src/diffpy/srfit/fitbase/simplerecipe.py
@@ -51,6 +51,13 @@ setCalculationPoints_dep_msg = build_deprecation_message(
     removal_version,
 )
 
+setEquation_dep_msg = build_deprecation_message(
+    base,
+    "setEquation",
+    "set_equation",
+    removal_version,
+)
+
 
 class SimpleRecipe(FitRecipe):
     """SimpleRecipe class.
@@ -224,6 +231,7 @@ class SimpleRecipe(FitRecipe):
         """
         return self.profile.set_calculation_range(xmin, xmax, dx)
 
+    @deprecated(setCalculationRange_dep_msg)
     def setCalculationRange(self, xmin=None, xmax=None, dx=None):
         """This function has been deprecated and will be removed in version
         4.0.0.
@@ -307,6 +315,18 @@ class SimpleRecipe(FitRecipe):
                 par.value = 0
             if par.name not in self._parameters:
                 self.addVar(par)
+        return
+
+    @deprecated(setEquation_dep_msg)
+    def setEquation(self, eqstr, ns={}):
+        """This function has been deprecated and will be removed in version
+        4.0.0.
+
+        Please use
+        diffpy.srfit.fitbase.simplerecipe.SimpleRecipe.set_equation
+        instead.
+        """
+        self.set_equation(eqstr, ns)
         return
 
     def __call__(self):

--- a/tests/test_contribution.py
+++ b/tests/test_contribution.py
@@ -155,6 +155,17 @@ class TestContribution(unittest.TestCase):
         self.assertEqual(len(xobs2), len(fc.residual()))
         return
 
+    def test_get_residual_equation(self):
+        """Check getting the current formula for residual equation."""
+        fc = self.fitcontribution
+        self.assertEqual("", fc.getResidualEquation())
+        fc.set_profile(self.profile)
+        fc.set_equation("A * x + B")
+        self.assertEqual("((eq - y) / dy)", fc.getResidualEquation())
+        fc.set_residual_equation("2 * (eq - y)")
+        self.assertEqual("(2 * (eq - y))", fc.getResidualEquation())
+        return
+
     def test_getResidualEquation(self):
         """Check getting the current formula for residual equation."""
         fc = self.fitcontribution
@@ -175,7 +186,7 @@ class TestContribution(unittest.TestCase):
         self.assertEqual(1, len(fc._eqfactory.equations))
         fc.set_profile(self.profile)
         for i in range(5):
-            fc.setResidualEquation("chiv")
+            fc.set_residual_equation("chiv")
         self.assertEqual(2, len(fc._eqfactory.equations))
         return
 
@@ -258,26 +269,26 @@ def testResidual(noObserversInGlobalBuilders):
 
     # Choose a new residual.
     fc.set_equation("2*I")
-    fc.setResidualEquation("resv")
+    fc.set_residual_equation("resv")
     chiv = fc.residual()
     assert dot(chiv, chiv) == pytest.approx(
         sum((2 * xobs - yobs) ** 2) / sum(yobs**2)
     )
 
     # Make a custom residual.
-    fc.setResidualEquation("abs(eq-y)**0.5")
+    fc.set_residual_equation("abs(eq-y)**0.5")
     chiv = fc.residual()
     assert dot(chiv, chiv) == pytest.approx(sum(abs(2 * xobs - yobs)))
 
     # Test configuration checks
     fc1 = FitContribution("test1")
     with pytest.raises(SrFitError):
-        fc1.setResidualEquation("chiv")
+        fc1.set_residual_equation("chiv")
     fc1.set_profile(profile)
     with pytest.raises(SrFitError):
-        fc1.setResidualEquation("chiv")
+        fc1.set_residual_equation("chiv")
     fc1.set_equation("A * x")
-    fc1.setResidualEquation("chiv")
+    fc1.set_residual_equation("chiv")
     assert noObserversInGlobalBuilders
     return
 

--- a/tests/test_contribution.py
+++ b/tests/test_contribution.py
@@ -158,23 +158,23 @@ class TestContribution(unittest.TestCase):
     def test_get_residual_equation(self):
         """Check getting the current formula for residual equation."""
         fc = self.fitcontribution
-        self.assertEqual("", fc.getResidualEquation())
+        self.assertEqual("", fc.get_residual_equation())
         fc.set_profile(self.profile)
         fc.set_equation("A * x + B")
-        self.assertEqual("((eq - y) / dy)", fc.getResidualEquation())
+        self.assertEqual("((eq - y) / dy)", fc.get_residual_equation())
         fc.set_residual_equation("2 * (eq - y)")
-        self.assertEqual("(2 * (eq - y))", fc.getResidualEquation())
+        self.assertEqual("(2 * (eq - y))", fc.get_residual_equation())
         return
 
     def test_getResidualEquation(self):
         """Check getting the current formula for residual equation."""
         fc = self.fitcontribution
-        self.assertEqual("", fc.getResidualEquation())
+        self.assertEqual("", fc.get_residual_equation())
         fc.set_profile(self.profile)
         fc.set_equation("A * x + B")
         self.assertEqual("((eq - y) / dy)", fc.getResidualEquation())
         fc.setResidualEquation("2 * (eq - y)")
-        self.assertEqual("(2 * (eq - y))", fc.getResidualEquation())
+        self.assertEqual("(2 * (eq - y))", fc.get_residual_equation())
         return
 
     def test_releaseOldEquations(self):


### PR DESCRIPTION
These are the final deprecation in `FitContribution`. Also I missed tagging a deprecated function in `SimpleRecipe` so I added it here. This slipped by because there are no direct tests for `SimpleRecipe`