### PR TITLE
deprecate: Deprecate remaining methods of `FitRecipe`

### DIFF
--- a/docs/examples/coreshellnp.py
+++ b/docs/examples/coreshellnp.py
@@ -96,7 +96,7 @@ def makeRecipe(stru1, stru2, datname):
     # Configure the fit variables
     # Start by configuring the scale factor and resolution factors.
     # We want the sum of the phase scale factors to be 1.
-    recipe.newVar("scale_CdS", 0.7)
+    recipe.create_new_variable("scale_CdS", 0.7)
     recipe.constrain(generator_cds.scale, "scale_CdS")
     recipe.constrain(generator_zns.scale, "1 - scale_CdS")
     # We also want the resolution factor to be the same on each.

--- a/docs/examples/coreshellnp.py
+++ b/docs/examples/coreshellnp.py
@@ -89,8 +89,8 @@ def makeRecipe(stru1, stru2, datname):
 
     # Vary the inner radius and thickness of the shell. Constrain the core
     # diameter to twice the shell radius.
-    recipe.addVar(contribution.radius, 15)
-    recipe.addVar(contribution.thickness, 11)
+    recipe.add_variable(contribution.radius, 15)
+    recipe.add_variable(contribution.thickness, 11)
     recipe.constrain(contribution.psize, "2 * radius")
 
     # Configure the fit variables
@@ -102,30 +102,34 @@ def makeRecipe(stru1, stru2, datname):
     # We also want the resolution factor to be the same on each.
 
     # Vary the global scale as well.
-    recipe.addVar(contribution.scale, 0.3)
+    recipe.add_variable(contribution.scale, 0.3)
 
     # Now we can configure the structural parameters. We tag the different
     # structural variables so we can easily turn them on and off in the
     # subsequent refinement.
     phase_cds = generator_cds.phase
     for par in phase_cds.sgpars.latpars:
-        recipe.addVar(par, name=par.name + "_cds", tag="lat")
+        recipe.add_variable(par, name=par.name + "_cds", tag="lat")
     for par in phase_cds.sgpars.adppars:
-        recipe.addVar(par, 1, name=par.name + "_cds", tag="adp")
-    recipe.addVar(phase_cds.sgpars.xyzpars.z_1, name="z_1_cds", tag="xyz")
+        recipe.add_variable(par, 1, name=par.name + "_cds", tag="adp")
+    recipe.add_variable(
+        phase_cds.sgpars.xyzpars.z_1, name="z_1_cds", tag="xyz"
+    )
     # Since we know these have stacking disorder, constrain the B33 adps for
     # each atom type.
     recipe.constrain("B33_1_cds", "B33_0_cds")
-    recipe.addVar(generator_cds.delta2, name="delta2_cds", value=5)
+    recipe.add_variable(generator_cds.delta2, name="delta2_cds", value=5)
 
     phase_zns = generator_zns.phase
     for par in phase_zns.sgpars.latpars:
-        recipe.addVar(par, name=par.name + "_zns", tag="lat")
+        recipe.add_variable(par, name=par.name + "_zns", tag="lat")
     for par in phase_zns.sgpars.adppars:
-        recipe.addVar(par, 1, name=par.name + "_zns", tag="adp")
-    recipe.addVar(phase_zns.sgpars.xyzpars.z_1, name="z_1_zns", tag="xyz")
+        recipe.add_variable(par, 1, name=par.name + "_zns", tag="adp")
+    recipe.add_variable(
+        phase_zns.sgpars.xyzpars.z_1, name="z_1_zns", tag="xyz"
+    )
     recipe.constrain("B33_1_zns", "B33_0_zns")
-    recipe.addVar(generator_zns.delta2, name="delta2_zns", value=2.5)
+    recipe.add_variable(generator_zns.delta2, name="delta2_zns", value=2.5)
 
     # Give the recipe away so it can be used!
     return recipe

--- a/docs/examples/crystalpdf.py
+++ b/docs/examples/crystalpdf.py
@@ -113,17 +113,17 @@ def makeRecipe(ciffile, datname):
     # the xyzpars, latpars, and adppars members of the SpaceGroupParameters
     # object.
     for par in sgpars.latpars:
-        recipe.addVar(par)
+        recipe.add_variable(par)
     for par in sgpars.adppars:
-        recipe.addVar(par, 0.005)
+        recipe.add_variable(par, 0.005)
 
     # We now select non-structural parameters to refine.
     # This controls the scaling of the PDF.
-    recipe.addVar(generator.scale, 1)
+    recipe.add_variable(generator.scale, 1)
     # This is a peak-damping resolution term.
-    recipe.addVar(generator.qdamp, 0.01)
+    recipe.add_variable(generator.qdamp, 0.01)
     # This is a vibrational correlation term that sharpens peaks at low-r.
-    recipe.addVar(generator.delta2, 5)
+    recipe.add_variable(generator.delta2, 5)
 
     # Give the recipe away so it can be used!
     return recipe

--- a/docs/examples/crystalpdfall.py
+++ b/docs/examples/crystalpdfall.py
@@ -111,23 +111,23 @@ def makeRecipe(
 
     # Now we vary and constrain Parameters as before.
     for par in phase_ni.sgpars:
-        recipe.addVar(par, name=par.name + "_ni")
+        recipe.add_variable(par, name=par.name + "_ni")
     delta2_ni = recipe.newVar("delta2_ni", 2.5)
     recipe.constrain(xgenerator_ni.delta2, delta2_ni)
     recipe.constrain(ngenerator_ni.delta2, delta2_ni)
     recipe.constrain(xgenerator_sini_ni.delta2, delta2_ni)
 
     for par in phase_si.sgpars:
-        recipe.addVar(par, name=par.name + "_si")
+        recipe.add_variable(par, name=par.name + "_si")
     delta2_si = recipe.newVar("delta2_si", 2.5)
     recipe.constrain(xgenerator_si.delta2, delta2_si)
     recipe.constrain(xgenerator_sini_si.delta2, delta2_si)
 
     # Now the experimental parameters
-    recipe.addVar(xgenerator_ni.scale, name="xscale_ni")
-    recipe.addVar(xgenerator_si.scale, name="xscale_si")
-    recipe.addVar(ngenerator_ni.scale, name="nscale_ni")
-    recipe.addVar(xcontribution_sini.scale, 1.0, "xscale_sini")
+    recipe.add_variable(xgenerator_ni.scale, name="xscale_ni")
+    recipe.add_variable(xgenerator_si.scale, name="xscale_si")
+    recipe.add_variable(ngenerator_ni.scale, name="nscale_ni")
+    recipe.add_variable(xcontribution_sini.scale, 1.0, "xscale_sini")
     recipe.newVar("pscale_sini_ni", 0.8)
     recipe.constrain(xgenerator_sini_ni.scale, "pscale_sini_ni")
     recipe.constrain(xgenerator_sini_si.scale, "1 - pscale_sini_ni")

--- a/docs/examples/crystalpdfall.py
+++ b/docs/examples/crystalpdfall.py
@@ -112,14 +112,14 @@ def makeRecipe(
     # Now we vary and constrain Parameters as before.
     for par in phase_ni.sgpars:
         recipe.add_variable(par, name=par.name + "_ni")
-    delta2_ni = recipe.newVar("delta2_ni", 2.5)
+    delta2_ni = recipe.create_new_variable("delta2_ni", 2.5)
     recipe.constrain(xgenerator_ni.delta2, delta2_ni)
     recipe.constrain(ngenerator_ni.delta2, delta2_ni)
     recipe.constrain(xgenerator_sini_ni.delta2, delta2_ni)
 
     for par in phase_si.sgpars:
         recipe.add_variable(par, name=par.name + "_si")
-    delta2_si = recipe.newVar("delta2_si", 2.5)
+    delta2_si = recipe.create_new_variable("delta2_si", 2.5)
     recipe.constrain(xgenerator_si.delta2, delta2_si)
     recipe.constrain(xgenerator_sini_si.delta2, delta2_si)
 
@@ -128,7 +128,7 @@ def makeRecipe(
     recipe.add_variable(xgenerator_si.scale, name="xscale_si")
     recipe.add_variable(ngenerator_ni.scale, name="nscale_ni")
     recipe.add_variable(xcontribution_sini.scale, 1.0, "xscale_sini")
-    recipe.newVar("pscale_sini_ni", 0.8)
+    recipe.create_new_variable("pscale_sini_ni", 0.8)
     recipe.constrain(xgenerator_sini_ni.scale, "pscale_sini_ni")
     recipe.constrain(xgenerator_sini_si.scale, "1 - pscale_sini_ni")
 

--- a/docs/examples/crystalpdfobjcryst.py
+++ b/docs/examples/crystalpdfobjcryst.py
@@ -90,18 +90,18 @@ def makeRecipe(ciffile, datname):
     # As before, we have one free lattice parameter ('a'). We can simplify
     # things by iterating through all the sgpars.
     for par in phase.sgpars:
-        recipe.addVar(par)
+        recipe.add_variable(par)
     # set the initial thermal factor to a non-zero value
     assert hasattr(recipe, "B11_0")
     recipe.B11_0 = 0.1
 
     # We now select non-structural parameters to refine.
     # This controls the scaling of the PDF.
-    recipe.addVar(generator.scale, 1)
+    recipe.add_variable(generator.scale, 1)
     # This is a peak-damping resolution term.
-    recipe.addVar(generator.qdamp, 0.01)
+    recipe.add_variable(generator.qdamp, 0.01)
     # This is a vibrational correlation term that sharpens peaks at low-r.
-    recipe.addVar(generator.delta2, 5)
+    recipe.add_variable(generator.delta2, 5)
 
     # Give the recipe away so it can be used!
     return recipe

--- a/docs/examples/crystalpdftwodata.py
+++ b/docs/examples/crystalpdftwodata.py
@@ -120,7 +120,7 @@ def makeRecipe(ciffile, xdatname, ndatname):
     recipe.add_variable(ngenerator.qdamp, 0.01, "nqdamp")
     # delta2 is a non-structual material property. Thus, we constrain together
     # delta2 Parameter from each PDFGenerator.
-    delta2 = recipe.newVar("delta2", 2)
+    delta2 = recipe.create_new_variable("delta2", 2)
     recipe.constrain(xgenerator.delta2, delta2)
     recipe.constrain(ngenerator.delta2, delta2)
 

--- a/docs/examples/crystalpdftwodata.py
+++ b/docs/examples/crystalpdftwodata.py
@@ -114,10 +114,10 @@ def makeRecipe(ciffile, xdatname, ndatname):
     recipe.add_contribution(ncontribution)
 
     # Now we vary and constrain Parameters as before.
-    recipe.addVar(xgenerator.scale, 1, "xscale")
-    recipe.addVar(ngenerator.scale, 1, "nscale")
-    recipe.addVar(xgenerator.qdamp, 0.01, "xqdamp")
-    recipe.addVar(ngenerator.qdamp, 0.01, "nqdamp")
+    recipe.add_variable(xgenerator.scale, 1, "xscale")
+    recipe.add_variable(ngenerator.scale, 1, "nscale")
+    recipe.add_variable(xgenerator.qdamp, 0.01, "xqdamp")
+    recipe.add_variable(ngenerator.qdamp, 0.01, "nqdamp")
     # delta2 is a non-structual material property. Thus, we constrain together
     # delta2 Parameter from each PDFGenerator.
     delta2 = recipe.newVar("delta2", 2)
@@ -128,7 +128,7 @@ def makeRecipe(ciffile, xdatname, ndatname):
     # ObjCrystCrystalParSet for the Crystal.
     phase = xgenerator.phase
     for par in phase.sgpars:
-        recipe.addVar(par)
+        recipe.add_variable(par)
     recipe.B11_0 = 0.1
 
     # Give the recipe away so it can be used!

--- a/docs/examples/crystalpdftwophase.py
+++ b/docs/examples/crystalpdftwophase.py
@@ -98,7 +98,7 @@ def makeRecipe(niciffile, siciffile, datname):
     recipe.constrain(generator_si.qdamp, "qdamp")
 
     # Vary the global scale as well.
-    recipe.addVar(contribution.scale, 1)
+    recipe.add_variable(contribution.scale, 1)
 
     # Now we can configure the structural parameters. Since we're using
     # ObjCrystCrystalParSets, the space group constraints are automatically
@@ -107,13 +107,13 @@ def makeRecipe(niciffile, siciffile, datname):
     # First the nickel parameters
     phase_ni = generator_ni.phase
     for par in phase_ni.sgpars:
-        recipe.addVar(par, name=par.name + "_ni")
-    recipe.addVar(generator_ni.delta2, name="delta2_ni")
+        recipe.add_variable(par, name=par.name + "_ni")
+    recipe.add_variable(generator_ni.delta2, name="delta2_ni")
     # Next the silicon parameters
     phase_si = generator_si.phase
     for par in phase_si.sgpars:
-        recipe.addVar(par, name=par.name + "_si")
-    recipe.addVar(generator_si.delta2, name="delta2_si")
+        recipe.add_variable(par, name=par.name + "_si")
+    recipe.add_variable(generator_si.delta2, name="delta2_si")
 
     # We have prior information from the earlier examples so we'll use it here
     # in the form of restraints.

--- a/docs/examples/crystalpdftwophase.py
+++ b/docs/examples/crystalpdftwophase.py
@@ -89,11 +89,11 @@ def makeRecipe(niciffile, siciffile, datname):
     # Configure the fit variables
     # Start by configuring the scale factor and resolution factors.
     # We want the sum of the phase scale factors to be 1.
-    recipe.newVar("scale_ni", 0.1)
+    recipe.create_new_variable("scale_ni", 0.1)
     recipe.constrain(generator_ni.scale, "scale_ni")
     recipe.constrain(generator_si.scale, "1 - scale_ni")
     # We also want the resolution factor to be the same on each.
-    recipe.newVar("qdamp", 0.03)
+    recipe.create_new_variable("qdamp", 0.03)
     recipe.constrain(generator_ni.qdamp, "qdamp")
     recipe.constrain(generator_si.qdamp, "qdamp")
 

--- a/docs/examples/debyemodel.py
+++ b/docs/examples/debyemodel.py
@@ -139,9 +139,9 @@ def makeRecipe():
     # Specify which Parameters we want to refine.
 
     # Vary the offset
-    recipe.addVar(contribution.offset, 0)
+    recipe.add_variable(contribution.offset, 0)
     # We also vary the Debye temperature.
-    recipe.addVar(contribution.thetaD, 100)
+    recipe.add_variable(contribution.thetaD, 100)
 
     # We would like to 'suggest' that the offset should remain positive. This
     # is somethine that we know about the system that might help the refinement

--- a/docs/examples/debyemodelII.py
+++ b/docs/examples/debyemodelII.py
@@ -83,8 +83,8 @@ def makeRecipeII():
     # Vary the offset from each FitContribution separately, while keeping the
     # Debye temperatures the same. We give each offset variable a different
     # name in the recipe so it retains its identity.
-    recipe.addVar(recipe.lowT.offset, name="lowToffset")
-    recipe.addVar(recipe.highT.offset, name="highToffset")
+    recipe.add_variable(recipe.lowT.offset, name="lowToffset")
+    recipe.add_variable(recipe.highT.offset, name="highToffset")
     # We create a new Variable and use the recipe's "constrain" method to
     # associate the Debye temperature parameters with that variable.
     recipe.newVar("thetaD", 100)

--- a/docs/examples/debyemodelII.py
+++ b/docs/examples/debyemodelII.py
@@ -87,7 +87,7 @@ def makeRecipeII():
     recipe.add_variable(recipe.highT.offset, name="highToffset")
     # We create a new Variable and use the recipe's "constrain" method to
     # associate the Debye temperature parameters with that variable.
-    recipe.newVar("thetaD", 100)
+    recipe.create_new_variable("thetaD", 100)
     recipe.constrain(recipe.lowT.thetaD, "thetaD")
     recipe.constrain(recipe.highT.thetaD, "thetaD")
     return recipe

--- a/docs/examples/ellipsoidsas.py
+++ b/docs/examples/ellipsoidsas.py
@@ -78,10 +78,10 @@ def makeRecipe(datname):
     # SASGenerator these are named like "radius_width".
     #
     # We want to fit the scale factor, radii and background factors.
-    recipe.addVar(generator.scale, 1)
-    recipe.addVar(generator.radius_a, 50)
-    recipe.addVar(generator.radius_b, 500)
-    recipe.addVar(generator.background, 0)
+    recipe.add_variable(generator.scale, 1)
+    recipe.add_variable(generator.radius_a, 50)
+    recipe.add_variable(generator.radius_b, 500)
+    recipe.add_variable(generator.background, 0)
 
     # Give the recipe away so it can be used!
     return recipe

--- a/docs/examples/gaussiangenerator.py
+++ b/docs/examples/gaussiangenerator.py
@@ -161,9 +161,9 @@ def makeRecipe():
     # that the Parameters belong to the GaussianGenerator, not the
     # FitContribution as in gaussianrecipe.py. We initialize parameters as in
     # gaussianrecipe.py so we can expect the same output.
-    recipe.addVar(generator.A, 1)
-    recipe.addVar(generator.x0, 5)
-    recipe.addVar(generator.sigma, name="sig")
+    recipe.add_variable(generator.A, 1)
+    recipe.add_variable(generator.x0, 5)
+    recipe.add_variable(generator.sigma, name="sig")
     recipe.sig.value = 1
 
     # Give the recipe away so it can be used!

--- a/docs/examples/gaussianrecipe.py
+++ b/docs/examples/gaussianrecipe.py
@@ -149,13 +149,13 @@ def makeRecipe():
     # Here we create a Variable for the 'A' Parameter from our fit equation.
     # The resulting Variable will be named 'A' as well, but it will be accessed
     # via the FitRecipe.
-    recipe.addVar(contribution.A)
+    recipe.add_variable(contribution.A)
     # Here we create the Variable for 'x0' and give it an initial value of 5.
-    recipe.addVar(contribution.x0, 5)
+    recipe.add_variable(contribution.x0, 5)
     # Here we create a Variable named 'sig', which is tied to the 'sigma'
     # Parameter of our FitContribution. We give it an initial value through the
     # FitRecipe instance.
-    recipe.addVar(contribution.sigma, name="sig")
+    recipe.add_variable(contribution.sigma, name="sig")
     recipe.sig.value = 1
 
     return recipe

--- a/docs/examples/interface.py
+++ b/docs/examples/interface.py
@@ -46,7 +46,7 @@ def main():
     # FitRecipe operations
     # "|="  -   Union of necessary components.
     # "+="  -   Add Parameter or create a new one. Each tuple is a set of
-    #           arguments for either setVar or addVar.
+    #           arguments for either setVar or add_variable.
     # "*="  -   Constrain a parameter. Think of "*" as a push-pin holding one
     #           parameter's value to that of another.
     # "%="  -   Restrain a parameter or equation. Think of "%" as a rope

--- a/docs/examples/npintensity.py
+++ b/docs/examples/npintensity.py
@@ -296,7 +296,7 @@ def makeRecipe(strufile, datname):
     # Variable that we call "Uiso" and constrain the atomic Uiso values to
     # this. Note that we don't give Uiso an initial value. The initial value
     # will be inferred from the following constraints.
-    Uiso = recipe.newVar("Uiso")
+    Uiso = recipe.create_new_variable("Uiso")
     for atom in phase.getScatterers():
         recipe.constrain(atom.Uiso, Uiso)
 

--- a/docs/examples/npintensity.py
+++ b/docs/examples/npintensity.py
@@ -263,20 +263,20 @@ def makeRecipe(strufile, datname):
     recipe.add_contribution(contribution)
 
     # Specify which parameters we want to refine.
-    recipe.addVar(contribution.b0, 0)
-    recipe.addVar(contribution.b1, 0)
-    recipe.addVar(contribution.b2, 0)
-    recipe.addVar(contribution.b3, 0)
-    recipe.addVar(contribution.b4, 0)
-    recipe.addVar(contribution.b5, 0)
-    recipe.addVar(contribution.b6, 0)
-    recipe.addVar(contribution.b7, 0)
-    recipe.addVar(contribution.b8, 0)
-    recipe.addVar(contribution.b9, 0)
+    recipe.add_variable(contribution.b0, 0)
+    recipe.add_variable(contribution.b1, 0)
+    recipe.add_variable(contribution.b2, 0)
+    recipe.add_variable(contribution.b3, 0)
+    recipe.add_variable(contribution.b4, 0)
+    recipe.add_variable(contribution.b5, 0)
+    recipe.add_variable(contribution.b6, 0)
+    recipe.add_variable(contribution.b7, 0)
+    recipe.add_variable(contribution.b8, 0)
+    recipe.add_variable(contribution.b9, 0)
 
     # We also want to adjust the scale and the convolution width
-    recipe.addVar(contribution.scale, 1)
-    recipe.addVar(contribution.width, 0.1)
+    recipe.add_variable(contribution.scale, 1)
+    recipe.add_variable(contribution.width, 0.1)
 
     # We can also refine structural parameters. Here we extract the
     # DiffpyStructureParSet from the intensity generator and use the parameters
@@ -289,7 +289,7 @@ def makeRecipe(strufile, datname):
     # constrained to a Variable by name. This has the same effect.
     lattice = phase.getLattice()
     a = lattice.a
-    recipe.addVar(a)
+    recipe.add_variable(a)
     recipe.constrain(lattice.b, a)
     recipe.constrain(lattice.c, a)
     # We want to refine the thermal parameters as well. We will add a new

--- a/docs/examples/npintensityII.py
+++ b/docs/examples/npintensityII.py
@@ -178,7 +178,7 @@ def makeRecipe(strufile, datname1, datname2):
     # variable that we call "Uiso" and constrain the atomic Uiso values to
     # this. Note that we don't give Uiso an initial value. The initial value
     # will be inferred from the subsequent constraints.
-    Uiso = recipe.newVar("Uiso")
+    Uiso = recipe.create_new_variable("Uiso")
     for atom in phase.getScatterers():
         recipe.constrain(atom.Uiso, Uiso)
 

--- a/docs/examples/npintensityII.py
+++ b/docs/examples/npintensityII.py
@@ -138,38 +138,38 @@ def makeRecipe(strufile, datname1, datname2):
     # background that we just defined in the FitContributions. We have to do
     # this separately for each FitContribution. We tag the variables so it is
     # easy to retrieve the background variables.
-    recipe.addVar(contribution1.b0, 0, name="b1_0", tag="bcoeffs1")
-    recipe.addVar(contribution1.b1, 0, name="b1_1", tag="bcoeffs1")
-    recipe.addVar(contribution1.b2, 0, name="b1_2", tag="bcoeffs1")
-    recipe.addVar(contribution1.b3, 0, name="b1_3", tag="bcoeffs1")
-    recipe.addVar(contribution1.b4, 0, name="b1_4", tag="bcoeffs1")
-    recipe.addVar(contribution1.b5, 0, name="b1_5", tag="bcoeffs1")
-    recipe.addVar(contribution1.b6, 0, name="b1_6", tag="bcoeffs1")
-    recipe.addVar(contribution1.b7, 0, name="b1_7", tag="bcoeffs1")
-    recipe.addVar(contribution1.b8, 0, name="b1_8", tag="bcoeffs1")
-    recipe.addVar(contribution1.b9, 0, name="b1_9", tag="bcoeffs1")
-    recipe.addVar(contribution2.b0, 0, name="b2_0", tag="bcoeffs2")
-    recipe.addVar(contribution2.b1, 0, name="b2_1", tag="bcoeffs2")
-    recipe.addVar(contribution2.b2, 0, name="b2_2", tag="bcoeffs2")
-    recipe.addVar(contribution2.b3, 0, name="b2_3", tag="bcoeffs2")
-    recipe.addVar(contribution2.b4, 0, name="b2_4", tag="bcoeffs2")
-    recipe.addVar(contribution2.b5, 0, name="b2_5", tag="bcoeffs2")
-    recipe.addVar(contribution2.b6, 0, name="b2_6", tag="bcoeffs2")
-    recipe.addVar(contribution2.b7, 0, name="b2_7", tag="bcoeffs2")
-    recipe.addVar(contribution2.b8, 0, name="b2_8", tag="bcoeffs2")
-    recipe.addVar(contribution2.b9, 0, name="b2_9", tag="bcoeffs2")
+    recipe.add_variable(contribution1.b0, 0, name="b1_0", tag="bcoeffs1")
+    recipe.add_variable(contribution1.b1, 0, name="b1_1", tag="bcoeffs1")
+    recipe.add_variable(contribution1.b2, 0, name="b1_2", tag="bcoeffs1")
+    recipe.add_variable(contribution1.b3, 0, name="b1_3", tag="bcoeffs1")
+    recipe.add_variable(contribution1.b4, 0, name="b1_4", tag="bcoeffs1")
+    recipe.add_variable(contribution1.b5, 0, name="b1_5", tag="bcoeffs1")
+    recipe.add_variable(contribution1.b6, 0, name="b1_6", tag="bcoeffs1")
+    recipe.add_variable(contribution1.b7, 0, name="b1_7", tag="bcoeffs1")
+    recipe.add_variable(contribution1.b8, 0, name="b1_8", tag="bcoeffs1")
+    recipe.add_variable(contribution1.b9, 0, name="b1_9", tag="bcoeffs1")
+    recipe.add_variable(contribution2.b0, 0, name="b2_0", tag="bcoeffs2")
+    recipe.add_variable(contribution2.b1, 0, name="b2_1", tag="bcoeffs2")
+    recipe.add_variable(contribution2.b2, 0, name="b2_2", tag="bcoeffs2")
+    recipe.add_variable(contribution2.b3, 0, name="b2_3", tag="bcoeffs2")
+    recipe.add_variable(contribution2.b4, 0, name="b2_4", tag="bcoeffs2")
+    recipe.add_variable(contribution2.b5, 0, name="b2_5", tag="bcoeffs2")
+    recipe.add_variable(contribution2.b6, 0, name="b2_6", tag="bcoeffs2")
+    recipe.add_variable(contribution2.b7, 0, name="b2_7", tag="bcoeffs2")
+    recipe.add_variable(contribution2.b8, 0, name="b2_8", tag="bcoeffs2")
+    recipe.add_variable(contribution2.b9, 0, name="b2_9", tag="bcoeffs2")
 
     # We also want to adjust the scale and the convolution width
-    recipe.addVar(contribution1.scale, 1, name="scale1")
-    recipe.addVar(contribution1.width, 0.1, name="width1")
-    recipe.addVar(contribution2.scale, 1, name="scale2")
-    recipe.addVar(contribution2.width, 0.1, name="width2")
+    recipe.add_variable(contribution1.scale, 1, name="scale1")
+    recipe.add_variable(contribution1.width, 0.1, name="width1")
+    recipe.add_variable(contribution2.scale, 1, name="scale2")
+    recipe.add_variable(contribution2.width, 0.1, name="width2")
 
     # We can also refine structural parameters. We only have to do this once,
     # since each generator holds the same DiffpyStructureParSet.
     phase = generator1.phase
     lattice = phase.getLattice()
-    a = recipe.addVar(lattice.a)
+    a = recipe.add_variable(lattice.a)
     # We want to allow for isotropic expansion, so we'll make constraints for
     # that.
     recipe.constrain(lattice.b, a)

--- a/docs/examples/nppdfcrystal.py
+++ b/docs/examples/nppdfcrystal.py
@@ -71,11 +71,11 @@ def makeRecipe(ciffile, grdata):
 
     phase = pdfgenerator.phase
     for par in phase.sgpars:
-        recipe.addVar(par)
+        recipe.add_variable(par)
 
-    recipe.addVar(pdfcontribution.psize, 20)
-    recipe.addVar(pdfgenerator.scale, 1)
-    recipe.addVar(pdfgenerator.delta2, 0)
+    recipe.add_variable(pdfcontribution.psize, 20)
+    recipe.add_variable(pdfgenerator.scale, 1)
+    recipe.add_variable(pdfgenerator.delta2, 0)
     recipe.B11_0 = 0.1
 
     return recipe

--- a/docs/examples/nppdfobjcryst.py
+++ b/docs/examples/nppdfobjcryst.py
@@ -101,8 +101,8 @@ def makeRecipe(molecule, datname):
 
     # Add the correlation term, scale. The scale is too short to effectively
     # determine qdamp.
-    recipe.addVar(generator.delta2, 2)
-    recipe.addVar(generator.scale, 1.3e4)
+    recipe.add_variable(generator.delta2, 2)
+    recipe.add_variable(generator.scale, 1.3e4)
 
     # Give the recipe away so it can be used!
     return recipe

--- a/docs/examples/nppdfobjcryst.py
+++ b/docs/examples/nppdfobjcryst.py
@@ -66,7 +66,7 @@ def makeRecipe(molecule, datname):
     c60 = generator.phase
 
     # First, the isotropic thermal displacement factor.
-    Biso = recipe.newVar("Biso")
+    Biso = recipe.create_new_variable("Biso")
     for atom in c60.getScatterers():
 
         # We have defined a 'center' atom that is a dummy, which means that it
@@ -88,7 +88,7 @@ def makeRecipe(molecule, datname):
     # that we don't give it an initial value. Since the variable is being
     # directly constrained to further below, its initial value will be inferred
     # from the constraint.
-    radius = recipe.newVar("radius")
+    radius = recipe.create_new_variable("radius")
     for i, atom in enumerate(c60.getScatterers()):
 
         if atom.isDummy():

--- a/docs/examples/nppdfsas.py
+++ b/docs/examples/nppdfsas.py
@@ -99,15 +99,15 @@ def makeRecipe(ciffile, grdata, iqdata):
     # PDF
     phase = pdfgenerator.phase
     for par in phase.sgpars:
-        recipe.addVar(par)
+        recipe.add_variable(par)
 
-    recipe.addVar(pdfgenerator.scale, 1)
-    recipe.addVar(pdfgenerator.delta2, 0)
+    recipe.add_variable(pdfgenerator.scale, 1)
+    recipe.add_variable(pdfgenerator.delta2, 0)
 
     # SAS
-    recipe.addVar(sasgenerator.scale, 1, name="iqscale")
-    recipe.addVar(sasgenerator.radius_a, 10)
-    recipe.addVar(sasgenerator.radius_b, 10)
+    recipe.add_variable(sasgenerator.scale, 1, name="iqscale")
+    recipe.add_variable(sasgenerator.radius_a, 10)
+    recipe.add_variable(sasgenerator.radius_b, 10)
 
     # Even though the cfcalculator and sasgenerator depend on the same sas
     # model, we must still constrain the cfcalculator Parameters so that it is

--- a/docs/examples/simplepdf.py
+++ b/docs/examples/simplepdf.py
@@ -54,13 +54,13 @@ def makeRecipe(ciffile, datname):
     sgpars = constrainAsSpaceGroup(phase, "Fm-3m")
 
     for par in sgpars.latpars:
-        recipe.addVar(par)
+        recipe.add_variable(par)
     for par in sgpars.adppars:
-        recipe.addVar(par, 0.005)
+        recipe.add_variable(par, 0.005)
 
-    recipe.addVar(contribution.scale, 1)
-    recipe.addVar(contribution.qdamp, 0.03, fixed=True)
-    recipe.addVar(contribution.nickel.delta2, 5)
+    recipe.add_variable(contribution.scale, 1)
+    recipe.add_variable(contribution.qdamp, 0.03, fixed=True)
+    recipe.add_variable(contribution.nickel.delta2, 5)
 
     # Give the recipe away so it can be used!
     return recipe

--- a/docs/examples/simplepdftwophase.py
+++ b/docs/examples/simplepdftwophase.py
@@ -51,10 +51,10 @@ def makeRecipe(niciffile, siciffile, datname):
     recipe.constrain(contribution.si.scale, "1 - scale_ni")
     # We also want the resolution factor to be the same on each. This is done
     # for free by the PDFContribution. We simply need to add it to the recipe.
-    recipe.addVar(contribution.qdamp, 0.03)
+    recipe.add_variable(contribution.qdamp, 0.03)
 
     # Vary the global scale as well.
-    recipe.addVar(contribution.scale, 1)
+    recipe.add_variable(contribution.scale, 1)
 
     # Now we can configure the structural parameters. Since we're using
     # ObjCrystCrystalParSets, the space group constraints are automatically
@@ -66,13 +66,13 @@ def makeRecipe(niciffile, siciffile, datname):
     # above.
     phase_ni = contribution.ni.phase
     for par in phase_ni.sgpars:
-        recipe.addVar(par, name=par.name + "_ni")
-    recipe.addVar(contribution.ni.delta2, name="delta2_ni")
+        recipe.add_variable(par, name=par.name + "_ni")
+    recipe.add_variable(contribution.ni.delta2, name="delta2_ni")
     # Next the silicon parameters
     phase_si = contribution.si.phase
     for par in phase_si.sgpars:
-        recipe.addVar(par, name=par.name + "_si")
-    recipe.addVar(contribution.si.delta2, name="delta2_si")
+        recipe.add_variable(par, name=par.name + "_si")
+    recipe.add_variable(contribution.si.delta2, name="delta2_si")
 
     # We have prior information from the earlier examples so we'll use it here
     # in the form of restraints.

--- a/docs/examples/simplepdftwophase.py
+++ b/docs/examples/simplepdftwophase.py
@@ -46,7 +46,7 @@ def makeRecipe(niciffile, siciffile, datname):
     # Configure the fit variables
     # Start by configuring the scale factor and resolution factors.
     # We want the sum of the phase scale factors to be 1.
-    recipe.newVar("scale_ni", 0.1)
+    recipe.create_new_variable("scale_ni", 0.1)
     recipe.constrain(contribution.ni.scale, "scale_ni")
     recipe.constrain(contribution.si.scale, "1 - scale_ni")
     # We also want the resolution factor to be the same on each. This is done

--- a/docs/examples/threedoublepeaks.py
+++ b/docs/examples/threedoublepeaks.py
@@ -126,8 +126,8 @@ def makeRecipe():
 
     # Vary the width of the peaks. We know the functional form of the peak
     # broadening.
-    recipe.newVar("sig0", 0.001)
-    recipe.newVar("dsig", 4)
+    recipe.create_new_variable("sig0", 0.001)
+    recipe.create_new_variable("dsig", 4)
 
     def sig(sig0, dsig, mu):
         """Calculate the peak broadening with respect to position."""

--- a/docs/examples/threedoublepeaks.py
+++ b/docs/examples/threedoublepeaks.py
@@ -101,14 +101,14 @@ def makeRecipe():
     recipe.add_contribution(contribution)
 
     # Vary the amplitudes for each double peak
-    recipe.addVar(contribution.A1, 100)
-    recipe.addVar(contribution.A2, 100)
-    recipe.addVar(contribution.A3, 100)
+    recipe.add_variable(contribution.A1, 100)
+    recipe.add_variable(contribution.A2, 100)
+    recipe.add_variable(contribution.A3, 100)
 
     # Vary the position of the first of the double peaks
-    recipe.addVar(contribution.mu11, 13.0)
-    recipe.addVar(contribution.mu21, 24.0)
-    recipe.addVar(contribution.mu31, 33.0)
+    recipe.add_variable(contribution.mu11, 13.0)
+    recipe.add_variable(contribution.mu21, 24.0)
+    recipe.add_variable(contribution.mu31, 33.0)
 
     # Constrain the position of the second double peak
     from numpy import arcsin, sin
@@ -158,13 +158,13 @@ def makeRecipe():
     )
 
     # Also the background
-    recipe.addVar(contribution.b0, 0, tag="bkgd")
-    recipe.addVar(contribution.b1, 0, tag="bkgd")
-    recipe.addVar(contribution.b2, 0, tag="bkgd")
-    recipe.addVar(contribution.b3, 0, tag="bkgd")
-    recipe.addVar(contribution.b4, 0, tag="bkgd")
-    recipe.addVar(contribution.b5, 0, tag="bkgd")
-    recipe.addVar(contribution.b6, 0, tag="bkgd")
+    recipe.add_variable(contribution.b0, 0, tag="bkgd")
+    recipe.add_variable(contribution.b1, 0, tag="bkgd")
+    recipe.add_variable(contribution.b2, 0, tag="bkgd")
+    recipe.add_variable(contribution.b3, 0, tag="bkgd")
+    recipe.add_variable(contribution.b4, 0, tag="bkgd")
+    recipe.add_variable(contribution.b5, 0, tag="bkgd")
+    recipe.add_variable(contribution.b6, 0, tag="bkgd")
     return recipe
 
 

--- a/news/fitrecipe-dep.rst
+++ b/news/fitrecipe-dep.rst
@@ -1,0 +1,32 @@
+**Added:**
+
+* Added ``create_new_variable`` method to ``FitRecipe``.
+* Added ``delete_variable`` method to ``FitRecipe``.
+* Added ``add_variable`` method to ``FitRecipe``.
+* Added ``scalar_residual`` method to ``FitRecipe``.
+* Added ``remove_parameter_set`` method to ``FitRecipe``.
+* Added test for ``remove_parameter_set`` and ``add_parameter_set`` method in ``FitRecipe``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* Deprecated ``newVar`` method for removal in 4.0.0.
+* Deprecated ``delVar`` method for removal in 4.0.0.
+* Deprecated ``addVar`` method for removal in 4.0.0.
+* Deprecated ``scalarResidual`` method for removal in 4.0.0.
+* Deprecated ``removeParameterSet`` method for removal in 4.0.0.
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/fitrecipe-dep.rst
+++ b/news/fitrecipe-dep.rst
@@ -5,7 +5,7 @@
 * Added ``add_variable`` method to ``FitRecipe``.
 * Added ``scalar_residual`` method to ``FitRecipe``.
 * Added ``remove_parameter_set`` method to ``FitRecipe``.
-* Added test for ``remove_parameter_set`` and ``add_parameter_set`` method in ``FitRecipe``.
+* Added test for ``remove_parameter_set`` method in ``FitRecipe``.
 
 **Changed:**
 

--- a/src/diffpy/srfit/fitbase/fitrecipe.py
+++ b/src/diffpy/srfit/fitbase/fitrecipe.py
@@ -87,6 +87,10 @@ scalarResidual_dep_msg = build_deprecation_message(
     base, "scalarResidual", "scalar_residual", removal_version
 )
 
+addVar_dep_msg = build_deprecation_message(
+    base, "addVar", "add_variable", removal_version
+)
+
 
 class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
     """FitRecipe class.
@@ -641,7 +645,7 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
 
     # Variable manipulation
 
-    def addVar(
+    def add_variable(
         self, par, value=None, name=None, fixed=False, tag=None, tags=[]
     ):
         """Add a variable to be refined.
@@ -679,22 +683,16 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
         Raises ValueError if par is constrained.
         """
         name = name or par.name
-
         if par.const:
             raise ValueError("The parameter '%s' is constant" % par)
-
         if par.constrained:
             raise ValueError("The parameter '%s' is constrained" % par)
-
         var = ParameterProxy(name, par)
         if value is not None:
             var.setValue(value)
-
         self._add_parameter(var)
-
         if fixed:
             self.fix(var)
-
         # Tag with passed tags and by name
         self._tagmanager.tag(var, var.name)
         self._tagmanager.tag(var, "all")
@@ -702,6 +700,17 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
         if tag is not None:
             self._tagmanager.tag(var, tag)
         return var
+
+    @deprecated(addVar_dep_msg)
+    def addVar(
+        self, par, value=None, name=None, fixed=False, tag=None, tags=[]
+    ):
+        """This function has been deprecated and will be removed in version
+        4.0.0.
+
+        Please use diffpy.srfit.fitbase.FitRecipe.add_variable instead.
+        """
+        return self.add_variable(par, value, name, fixed, tag, tags)
 
     def delVar(self, var):
         """Remove a variable.

--- a/src/diffpy/srfit/fitbase/fitrecipe.py
+++ b/src/diffpy/srfit/fitbase/fitrecipe.py
@@ -83,6 +83,10 @@ removeParameterSet_dep_msg = build_deprecation_message(
     base, "removeParameterSet", "remove_parameter_set", removal_version
 )
 
+scalarResidual_dep_msg = build_deprecation_message(
+    base, "scalarResidual", "scalar_residual", removal_version
+)
+
 
 class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
     """FitRecipe class.
@@ -448,7 +452,7 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
 
         return chiv
 
-    def scalarResidual(self, p=[]):
+    def scalar_residual(self, p=[]):
         """Calculate the scalar residual to be optimized.
 
         Parameters
@@ -468,9 +472,19 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
         chiv = self.residual(p)
         return dot(chiv, chiv)
 
+    @deprecated(scalarResidual_dep_msg)
+    def scalarResidual(self, p=[]):
+        """This function has been deprecated and will be removed in version
+        4.0.0.
+
+        Please use diffpy.srfit.fitbase.FitRecipe.scalar_residual
+        instead.
+        """
+        return self.scalar_residual(p)
+
     def __call__(self, p=[]):
-        """Same as scalarResidual method."""
-        return self.scalarResidual(p)
+        """Same as scalar_residual method."""
+        return self.scalar_residual(p)
 
     def _prepare(self):
         """Prepare for the residual calculation, if necessary.

--- a/src/diffpy/srfit/fitbase/fitrecipe.py
+++ b/src/diffpy/srfit/fitbase/fitrecipe.py
@@ -79,6 +79,10 @@ addparset_dep_msg = build_deprecation_message(
     base, "addParameterSet", "add_parameter_set", removal_version
 )
 
+removeParameterSet_dep_msg = build_deprecation_message(
+    base, "removeParameterSet", "remove_parameter_set", removal_version
+)
+
 
 class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
     """FitRecipe class.
@@ -375,12 +379,22 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
         self.add_parameter_set(parset)
         return
 
-    def removeParameterSet(self, parset):
+    def remove_parameter_set(self, parset):
         """Remove a ParameterSet from the hierarchy.
 
         Raises ValueError if parset is not managed by this object.
         """
         self._remove_object(parset, self._parsets)
+        return
+
+    @deprecated(removeParameterSet_dep_msg)
+    def removeParameterSet(self, parset):
+        """This function has been deprecated and will be removed in version
+        4.0.0.
+
+        Please use diffpy.srfit.fitbase.FitRecipe.remove_parameter_set instead.
+        """
+        self.remove_parameter_set(parset)
         return
 
     def residual(self, p=[]):

--- a/src/diffpy/srfit/fitbase/fitrecipe.py
+++ b/src/diffpy/srfit/fitbase/fitrecipe.py
@@ -95,6 +95,10 @@ delVar_dep_msg = build_deprecation_message(
     base, "delVar", "delete_variable", removal_version
 )
 
+newVar_dep_msg = build_deprecation_message(
+    base, "newVar", "create_new_variable", removal_version
+)
+
 
 class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
     """FitRecipe class.
@@ -752,7 +756,9 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
         super(FitRecipe, self).__delattr__(name)
         return
 
-    def newVar(self, name, value=None, fixed=False, tag=None, tags=[]):
+    def create_new_variable(
+        self, name, value=None, fixed=False, tag=None, tags=[]
+    ):
         """Create a new variable of the fit.
 
         This method lets new variables be created that are not tied to a
@@ -786,17 +792,24 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
         """
         # This will fix the Parameter
         var = self._new_parameter(name, value)
-
         # We may explicitly free it
         if not fixed:
             self.free(var)
-
         # Tag with passed tags
         self._tagmanager.tag(var, *tags)
         if tag is not None:
             self._tagmanager.tag(var, tag)
 
         return var
+
+    @deprecated(newVar_dep_msg)
+    def newVar(self, name, value=None, fixed=False, tag=None, tags=[]):
+        """This function has been deprecated and will be removed in version
+        4.0.0.
+
+        Please use diffpy.srfit.fitbase.FitRecipe.create_new_variable instead.
+        """
+        return self.create_new_variable(name, value, fixed, tag, tags)
 
     def _new_parameter(self, name, value, check=True):
         """Overloaded to tag variables.

--- a/src/diffpy/srfit/fitbase/fitrecipe.py
+++ b/src/diffpy/srfit/fitbase/fitrecipe.py
@@ -91,6 +91,10 @@ addVar_dep_msg = build_deprecation_message(
     base, "addVar", "add_variable", removal_version
 )
 
+delVar_dep_msg = build_deprecation_message(
+    base, "delVar", "delete_variable", removal_version
+)
+
 
 class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
     """FitRecipe class.
@@ -712,7 +716,7 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
         """
         return self.add_variable(par, value, name, fixed, tag, tags)
 
-    def delVar(self, var):
+    def delete_variable(self, var):
         """Remove a variable.
 
         Note that constraints and restraints involving the variable are not
@@ -731,9 +735,19 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
         self._tagmanager.untag(var)
         return
 
+    @deprecated(delVar_dep_msg)
+    def delVar(self, var):
+        """This function has been deprecated and will be removed in version
+        4.0.0.
+
+        Please use diffpy.srfit.fitbase.FitRecipe.delete_variable instead.
+        """
+        self.delete_variable(var)
+        return
+
     def __delattr__(self, name):
         if name in self._parameters:
-            self.delVar(self._parameters[name])
+            self.delete_variable(self._parameters[name])
             return
         super(FitRecipe, self).__delattr__(name)
         return

--- a/src/diffpy/srfit/fitbase/parameterset.py
+++ b/src/diffpy/srfit/fitbase/parameterset.py
@@ -34,6 +34,10 @@ addparset_dep_msg = build_deprecation_message(
     base, "addParameterSet", "add_parameter_set", removal_version
 )
 
+removeParameterSet_dep_msg = build_deprecation_message(
+    base, "removeParameterSet", "remove_parameter_set", removal_version
+)
+
 
 class ParameterSet(RecipeOrganizer):
     """Class for organizing Parameters and other ParameterSets.
@@ -123,12 +127,24 @@ class ParameterSet(RecipeOrganizer):
         self.add_parameter_set(parset)
         return
 
-    def removeParameterSet(self, parset):
+    def remove_parameter_set(self, parset):
         """Remove a ParameterSet from the hierarchy.
 
         Raises ValueError if parset is not managed by this object.
         """
         self._remove_object(parset, self._parsets)
+        return
+
+    @deprecated(removeParameterSet_dep_msg)
+    def removeParameterSet(self, parset):
+        """This function has been deprecated and will be removed in version
+        4.0.0.
+
+        Please use
+        diffpy.srfit.fitbase.parameterset.ParameterSet.remove_parameter_set
+        instead.
+        """
+        self.remove_parameter_set(parset)
         return
 
     def setConst(self, const=True):

--- a/src/diffpy/srfit/fitbase/simplerecipe.py
+++ b/src/diffpy/srfit/fitbase/simplerecipe.py
@@ -314,7 +314,7 @@ class SimpleRecipe(FitRecipe):
             if par.value is None:
                 par.value = 0
             if par.name not in self._parameters:
-                self.addVar(par)
+                self.add_variable(par)
         return
 
     @deprecated(setEquation_dep_msg)

--- a/src/diffpy/srfit/interface/interface.py
+++ b/src/diffpy/srfit/interface/interface.py
@@ -119,7 +119,7 @@ class FitRecipeInterface(object):
         return self
 
     def __iadd__(self, args):
-        """AddVar or newVar with +=
+        """add_variable or create_new_variable with +=
 
         Think of "+" as addition of a variable.
 
@@ -127,10 +127,10 @@ class FitRecipeInterface(object):
         arguments or argument tuples.
         """
 
-        # Want to detect add_variable or newVar
+        # Want to detect add_variable or create_new_variable
         def f(*args):
             if isinstance(args[0], six.string_types):
-                self.newVar(*args)
+                self.create_new_variable(*args)
             else:
                 self.add_variable(*args)
             return

--- a/src/diffpy/srfit/interface/interface.py
+++ b/src/diffpy/srfit/interface/interface.py
@@ -127,12 +127,12 @@ class FitRecipeInterface(object):
         arguments or argument tuples.
         """
 
-        # Want to detect addVar or newVar
+        # Want to detect add_variable or newVar
         def f(*args):
             if isinstance(args[0], six.string_types):
                 self.newVar(*args)
             else:
-                self.addVar(*args)
+                self.add_variable(*args)
             return
 
         _applymanyargs(args, f)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,9 +158,9 @@ def build_recipe_one_contribution():
     contribution.set_equation("A*sin(k*x + c)")
     recipe = FitRecipe()
     recipe.add_contribution(contribution)
-    recipe.addVar(contribution.A, 1)
-    recipe.addVar(contribution.k, 1)
-    recipe.addVar(contribution.c, 1)
+    recipe.add_variable(contribution.A, 1)
+    recipe.add_variable(contribution.k, 1)
+    recipe.add_variable(contribution.c, 1)
     return recipe
 
 
@@ -184,12 +184,12 @@ def build_recipe_two_contributions():
     recipe = FitRecipe()
     recipe.add_contribution(contribution1)
     recipe.add_contribution(contribution2)
-    recipe.addVar(contribution1.A, 1)
-    recipe.addVar(contribution1.k, 1)
-    recipe.addVar(contribution1.c, 1)
-    recipe.addVar(contribution2.B, 0.5)
-    recipe.addVar(contribution2.m, 2)
-    recipe.addVar(contribution2.d, 0)
+    recipe.add_variable(contribution1.A, 1)
+    recipe.add_variable(contribution1.k, 1)
+    recipe.add_variable(contribution1.c, 1)
+    recipe.add_variable(contribution2.B, 0.5)
+    recipe.add_variable(contribution2.m, 2)
+    recipe.add_variable(contribution2.d, 0)
 
     return recipe
 

--- a/tests/test_fitrecipe.py
+++ b/tests/test_fitrecipe.py
@@ -120,7 +120,7 @@ class TestFitRecipe(unittest.TestCase):
         recipe.constrain(recipe.B, p)
         values = recipe.getValues()
         self.assertTrue((values == [2, 1, 0]).all())
-        recipe.delVar(recipe.B)
+        recipe.delete_variable(recipe.B)
 
         recipe.fix(recipe.k)
 
@@ -246,7 +246,7 @@ class TestFitRecipe(unittest.TestCase):
 
         # Remove the restraint and variable
         self.recipe.unrestrain(r1)
-        self.recipe.delVar(self.recipe.Avar)
+        self.recipe.delete_variable(self.recipe.Avar)
         self.recipe._ready = False
         res = self.recipe.residual()
         chi2 = 0

--- a/tests/test_fitrecipe.py
+++ b/tests/test_fitrecipe.py
@@ -58,9 +58,9 @@ class TestFitRecipe(unittest.TestCase):
         recipe = self.recipe
         con = self.fitcontribution
 
-        recipe.addVar(con.A, 2, tag="tagA")
-        recipe.addVar(con.k, 1, tag="tagk")
-        recipe.addVar(con.c, 0)
+        recipe.add_variable(con.A, 2, tag="tagA")
+        recipe.add_variable(con.k, 1, tag="tagk")
+        recipe.add_variable(con.c, 0)
         recipe.newVar("B", 0)
 
         self.assertTrue(recipe.isFree(recipe.A))
@@ -100,13 +100,61 @@ class TestFitRecipe(unittest.TestCase):
         self.assertRaises(ValueError, recipe.fix, "junk")
         return
 
+    def test_variables(self):
+        """Test to see if variables are added and removed properly."""
+        recipe = self.recipe
+        con = self.fitcontribution
+
+        recipe.add_variable(con.A, 2)
+        recipe.add_variable(con.k, 1)
+        recipe.add_variable(con.c, 0)
+        recipe.newVar("B", 0)
+
+        names = recipe.getNames()
+        self.assertEqual(names, ["A", "k", "c", "B"])
+        values = recipe.getValues()
+        self.assertTrue((values == [2, 1, 0, 0]).all())
+
+        # Constrain a parameter to the B-variable to give it a value
+        p = Parameter("Bpar", -1)
+        recipe.constrain(recipe.B, p)
+        values = recipe.getValues()
+        self.assertTrue((values == [2, 1, 0]).all())
+        recipe.delVar(recipe.B)
+
+        recipe.fix(recipe.k)
+
+        names = recipe.getNames()
+        self.assertEqual(names, ["A", "c"])
+        values = recipe.getValues()
+        self.assertTrue((values == [2, 0]).all())
+
+        recipe.fix("all")
+        names = recipe.getNames()
+        self.assertEqual(names, [])
+        values = recipe.getValues()
+        self.assertTrue((values == []).all())
+
+        recipe.free("all")
+        names = recipe.getNames()
+        self.assertEqual(3, len(names))
+        self.assertTrue("A" in names)
+        self.assertTrue("k" in names)
+        self.assertTrue("c" in names)
+        values = recipe.getValues()
+        self.assertEqual(3, len(values))
+        self.assertTrue(0 in values)
+        self.assertTrue(1 in values)
+        self.assertTrue(2 in values)
+        return
+
     def testVars(self):
         """Test to see if variables are added and removed properly."""
         recipe = self.recipe
         con = self.fitcontribution
 
-        recipe.addVar(con.A, 2)
-        recipe.addVar(con.k, 1)
+        recipe.add_variable(con.A, 2)
+        recipe.add_variable(con.k, 1)
         recipe.addVar(con.c, 0)
         recipe.newVar("B", 0)
 
@@ -270,7 +318,7 @@ def testPrintFitHook(capturestdout):
 
     recipe.addContribution(fitcontribution)
 
-    recipe.addVar(fitcontribution.c)
+    recipe.add_variable(fitcontribution.c)
     recipe.restrain("c", lb=5)
     (pfh,) = recipe.getFitHooks()
     out = capturestdout(recipe.scalar_residual)
@@ -346,7 +394,7 @@ def test_add_contribution(capturestdout):
 
     recipe.add_contribution(fitcontribution)
 
-    recipe.addVar(fitcontribution.c)
+    recipe.add_variable(fitcontribution.c)
     recipe.restrain("c", lb=5)
     (pfh,) = recipe.get_fit_hooks()
     out = capturestdout(recipe.scalar_residual)
@@ -404,8 +452,8 @@ def build_recipe_from_datafile(datafile):
     contribution.set_equation("m*x + b")
     recipe = FitRecipe()
     recipe.add_contribution(contribution)
-    recipe.addVar(contribution.m, 1)
-    recipe.addVar(contribution.b, 0)
+    recipe.add_variable(contribution.m, 1)
+    recipe.add_variable(contribution.b, 0)
     return recipe
 
 
@@ -425,8 +473,8 @@ def build_recipe_from_datafile_deprecated(datafile):
     contribution.set_equation("m*x + b")
     recipe = FitRecipe()
     recipe.add_contribution(contribution)
-    recipe.addVar(contribution.m, 1)
-    recipe.addVar(contribution.b, 0)
+    recipe.add_variable(contribution.m, 1)
+    recipe.add_variable(contribution.b, 0)
     return recipe
 
 

--- a/tests/test_fitrecipe.py
+++ b/tests/test_fitrecipe.py
@@ -291,6 +291,34 @@ def testPrintFitHook(capturestdout):
     return
 
 
+def test_add_and_remove_ParameterSet():
+    # add a parset
+    recipe = FitRecipe("recipe")
+    parameter_to_add = Parameter("added_param", 1)
+    recipe.addParameterSet(parameter_to_add)
+    # check that the parameter is added
+    assert recipe.added_param == parameter_to_add
+    assert recipe.added_param.value == 1
+    # remove the added parameter
+    recipe.removeParameterSet(parameter_to_add)
+    # check that the parameter is removed
+    assert not hasattr(recipe, "added_param")
+
+
+def test_add_and_remove_parameter_set():
+    recipe = FitRecipe("recipe")
+    parameter_to_add = Parameter("added_param", 1)
+    # add a parset
+    recipe.add_parameter_set(parameter_to_add)
+    # check that the parameter is added
+    assert recipe.added_param == parameter_to_add
+    assert recipe.added_param.value == 1
+    # remove the added parameter
+    recipe.remove_parameter_set(parameter_to_add)
+    # check that the parameter is removed
+    assert not hasattr(recipe, "added_param")
+
+
 def test_add_contribution(capturestdout):
     """Duplicated test of PrintFitHooks except addContribution method has
     changed to the new add_contribution method. This is because addContribution

--- a/tests/test_fitrecipe.py
+++ b/tests/test_fitrecipe.py
@@ -61,7 +61,7 @@ class TestFitRecipe(unittest.TestCase):
         recipe.add_variable(con.A, 2, tag="tagA")
         recipe.add_variable(con.k, 1, tag="tagk")
         recipe.add_variable(con.c, 0)
-        recipe.newVar("B", 0)
+        recipe.create_new_variable("B", 0)
 
         self.assertTrue(recipe.isFree(recipe.A))
         recipe.fix("tagA")
@@ -108,7 +108,7 @@ class TestFitRecipe(unittest.TestCase):
         recipe.add_variable(con.A, 2)
         recipe.add_variable(con.k, 1)
         recipe.add_variable(con.c, 0)
-        recipe.newVar("B", 0)
+        recipe.create_new_variable("B", 0)
 
         names = recipe.getNames()
         self.assertEqual(names, ["A", "k", "c", "B"])
@@ -212,7 +212,7 @@ class TestFitRecipe(unittest.TestCase):
 
         # Try some constraints
         # Make c = 2*A, A = Avar
-        var = self.recipe.newVar("Avar")
+        var = self.recipe.create_new_variable("Avar")
         self.recipe.constrain(
             self.fitcontribution.c, "2*A", {"A": self.fitcontribution.A}
         )

--- a/tests/test_fitrecipe.py
+++ b/tests/test_fitrecipe.py
@@ -273,14 +273,14 @@ def testPrintFitHook(capturestdout):
     recipe.addVar(fitcontribution.c)
     recipe.restrain("c", lb=5)
     (pfh,) = recipe.getFitHooks()
-    out = capturestdout(recipe.scalarResidual)
+    out = capturestdout(recipe.scalar_residual)
     assert "" == out
     pfh.verbose = 1
-    out = capturestdout(recipe.scalarResidual)
+    out = capturestdout(recipe.scalar_residual)
     assert out.strip().isdigit()
     assert "\nRestraints:" not in out
     pfh.verbose = 2
-    out = capturestdout(recipe.scalarResidual)
+    out = capturestdout(recipe.scalar_residual)
     assert "\nResidual:" in out
     assert "\nRestraints:" in out
     assert "\nVariables" not in out
@@ -349,19 +349,19 @@ def test_add_contribution(capturestdout):
     recipe.addVar(fitcontribution.c)
     recipe.restrain("c", lb=5)
     (pfh,) = recipe.get_fit_hooks()
-    out = capturestdout(recipe.scalarResidual)
+    out = capturestdout(recipe.scalar_residual)
     assert "" == out
     pfh.verbose = 1
-    out = capturestdout(recipe.scalarResidual)
+    out = capturestdout(recipe.scalar_residual)
     assert out.strip().isdigit()
     assert "\nRestraints:" not in out
     pfh.verbose = 2
-    out = capturestdout(recipe.scalarResidual)
+    out = capturestdout(recipe.scalar_residual)
     assert "\nResidual:" in out
     assert "\nRestraints:" in out
     assert "\nVariables" not in out
     pfh.verbose = 3
-    out = capturestdout(recipe.scalarResidual)
+    out = capturestdout(recipe.scalar_residual)
     assert "\nVariables" in out
     assert "c = " in out
     return

--- a/tests/test_fitresults.py
+++ b/tests/test_fitresults.py
@@ -24,9 +24,9 @@ from diffpy.srfit.fitbase.fitresults import initializeRecipe
 
 def testInitializeFromFileName(datafile):
     recipe = FitRecipe("recipe")
-    recipe.newVar("A", 0)
-    recipe.newVar("sig", 0)
-    recipe.newVar("x0", 0)
+    recipe.create_new_variable("A", 0)
+    recipe.create_new_variable("sig", 0)
+    recipe.create_new_variable("x0", 0)
     filename = datafile("results.res")
     Aval = 5.77619823e-01
     sigval = -9.22758690e-01
@@ -44,9 +44,9 @@ def testInitializeFromFileName(datafile):
 
 def testInitializeFromFileObj(datafile):
     recipe = FitRecipe("recipe")
-    recipe.newVar("A", 0)
-    recipe.newVar("sig", 0)
-    recipe.newVar("x0", 0)
+    recipe.create_new_variable("A", 0)
+    recipe.create_new_variable("sig", 0)
+    recipe.create_new_variable("x0", 0)
     filename = datafile("results.res")
     Aval = 5.77619823e-01
     sigval = -9.22758690e-01
@@ -67,9 +67,9 @@ def testInitializeFromFileObj(datafile):
 
 def testInitializeFromString(datafile):
     recipe = FitRecipe("recipe")
-    recipe.newVar("A", 0)
-    recipe.newVar("sig", 0)
-    recipe.newVar("x0", 0)
+    recipe.create_new_variable("A", 0)
+    recipe.create_new_variable("sig", 0)
+    recipe.create_new_variable("x0", 0)
     filename = datafile("results.res")
     Aval = 5.77619823e-01
     sigval = -9.22758690e-01

--- a/tests/test_sgconstraints.py
+++ b/tests/test_sgconstraints.py
@@ -100,7 +100,7 @@ def test_ObjCryst_constrain_space_group(pyobjcryst_available):
 
     f = FitRecipe()
     with pytest.raises(ValueError):
-        f.addVar(mn.x)
+        f.add_variable(mn.x)
 
     return
 


### PR DESCRIPTION
deprecated,

- `removeParameterSet`
- `scalarResidual`
- `addVar`
- `delVar`
- `newVar`

I also added a test for `remove_parameter_set` since it didn't exist