### PR TITLE
Deprecate and refactor: Deprecate and refactor `initializeResults` and `resultsDictionary`

### DIFF
--- a/news/fitresults-dep.rst
+++ b/news/fitresults-dep.rst
@@ -2,7 +2,7 @@
 
 * Added ``save_results`` method to ``FitResults``.
 * Added ``print_results`` method to ``FitResults``.
-* Added ``get_results_string`` method to ``FitResults``.
+* Added ``format_results_string`` method to ``FitResults``.
 
 **Changed:**
 

--- a/news/refactor-fitresults.rst
+++ b/news/refactor-fitresults.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* Added ``get_results_dictionary`` method to ``FitResults`` to with improved parsing abilities.
+* Added ``initialize_recipe_from_results`` method to ``FitRecipe`` to initialize a recipe from a ``FitResults`` object or text file.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* Deprecated ``initializeResults`` for removal in 4.0.0. Use ``FitRecipe.initialize_recipe_from_results`` instead.
+* Deprecated ``resultsDictionary`` for removal in 4.0.0. Use ``FitResults.get_results_dictionary`` instead.
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/srfit/fitbase/fitrecipe.py
+++ b/src/diffpy/srfit/fitbase/fitrecipe.py
@@ -1498,13 +1498,16 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
             raise ValueError(
                 "results must be a FitResults object, str, or pathlib.Path"
             )
-        # Remove metrics like Rw from the dict, leaving only parameter values
+        # Remove metrics like Rw from the dict, leaving only parameter values.
+        # If a non-refinable quantity is ever stored as a tuple in the
+        # results dictionary, it will be incorrectly treated as a parameter
+        # and included here, which could lead to errors.
         parameters_dict = {
             k: v for k, v in results_dict.items() if isinstance(v, tuple)
         }
         return parameters_dict
 
-    def initialize_recipe_from_results(self, results):
+    def initialize_recipe_from_results(self, results, verbose=True):
         """Initialize the variable values from a previous fit result.
 
         Parameters
@@ -1512,11 +1515,21 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
         results : FitResults object, str, or pathlib.Path object
             The results from a previous fit. These results should
             have the same parameters as the current FitRecipe.
+        verbose : bool, optional
+            If True, print the initialized parameter values. Default is True.
         """
         parameters_dict = self._prepare_results_for_initialization(results)
+
+        if verbose:
+            print("\nInitializing FitRecipe from results")
+            print("-" * 40)
+        if verbose and parameters_dict:
+            width = max(len(name) for name in parameters_dict)
         for name, (value, uncertainty) in parameters_dict.items():
             if name in self._parameters:
                 self._parameters[name].setValue(value)
+                if verbose:
+                    print(f"{name:<{width}} = {value}")
 
 
 # End of file

--- a/src/diffpy/srfit/fitbase/fitrecipe.py
+++ b/src/diffpy/srfit/fitbase/fitrecipe.py
@@ -35,6 +35,7 @@ problem using FitRecipe.
 __all__ = ["FitRecipe"]
 
 from collections import OrderedDict
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 from bg_mpl_stylesheets.styles import all_styles
@@ -1475,6 +1476,48 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
         """Notify RecipeContainers in hierarchy of configuration change."""
         self._ready = False
         return
+
+    def _load_results_file(self, results_path):
+        """Load a saved FitResults file and return parsed values."""
+        from diffpy.srfit.fitbase import FitResults
+
+        with open(results_path) as f:
+            text = f.read()
+        results_dict = FitResults._parse_results_text(text)
+        return results_dict
+
+    def _prepare_result_for_initialization(self, results):
+        from diffpy.srfit.fitbase import FitResults
+
+        if isinstance(results, FitResults):
+            results_dict = results.get_results_dictionary()
+        elif isinstance(results, (str, Path)):
+            results_path = Path(results)
+            results_dict = self._load_results_file(results_path)
+        else:
+            raise ValueError(
+                "results must be a FitResults object, str, or pathlib.Path"
+            )
+        # Remove metrics like Rw from the dict, leaving only parameter values
+        parameters_dict = {
+            k: v for k, v in results_dict.items() if isinstance(v, tuple)
+        }
+        return parameters_dict
+
+    def initialize_recipe_from_results(self, results):
+        """Initialize the variable values from a previous fit result.
+
+        Parameters
+        ----------
+        results : FitResults object, str, or pathlib.Path object
+            A FitResults object from a previous fit. The variable values will
+            be taken from the 'x' attribute of the FitResults object,
+            which is the list of variable values at the best fit.
+        """
+        parameters_dict = self._prepare_result_for_initialization(results)
+        for name, (value, uncertainty) in parameters_dict.items():
+            if name in self._parameters:
+                self._parameters[name].setValue(value)
 
 
 # End of file

--- a/src/diffpy/srfit/fitbase/fitrecipe.py
+++ b/src/diffpy/srfit/fitbase/fitrecipe.py
@@ -1510,9 +1510,8 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
         Parameters
         ----------
         results : FitResults object, str, or pathlib.Path object
-            A FitResults object from a previous fit. The variable values will
-            be taken from the 'x' attribute of the FitResults object,
-            which is the list of variable values at the best fit.
+            The results from a previous fit. These results should
+            have the same parameters as the current FitRecipe.
         """
         parameters_dict = self._prepare_results_for_initialization(results)
         for name, (value, uncertainty) in parameters_dict.items():

--- a/src/diffpy/srfit/fitbase/fitrecipe.py
+++ b/src/diffpy/srfit/fitbase/fitrecipe.py
@@ -42,6 +42,7 @@ from bg_mpl_stylesheets.styles import all_styles
 from numpy import array, concatenate, dot, sqrt
 
 from diffpy.srfit.fitbase.fithook import PrintFitHook
+from diffpy.srfit.fitbase.fitresults import _parse_results_text
 from diffpy.srfit.fitbase.parameter import ParameterProxy
 from diffpy.srfit.fitbase.recipeorganizer import RecipeOrganizer
 from diffpy.srfit.interface import _fitrecipe_interface
@@ -1479,24 +1480,23 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
 
     def _load_results_file(self, results_path):
         """Load a saved FitResults file and return parsed values."""
-        from diffpy.srfit.fitbase import FitResults
-
         with open(results_path) as f:
             text = f.read()
-        results_dict = FitResults._parse_results_text(text)
+        results_dict = _parse_results_text(text)
         return results_dict
 
     def _prepare_results_for_initialization(self, results):
-        from diffpy.srfit.fitbase import FitResults
-
-        if isinstance(results, FitResults):
+        if hasattr(results, "get_results_dictionary"):
             results_dict = results.get_results_dictionary()
         elif isinstance(results, (str, Path)):
             results_path = Path(results)
             results_dict = self._load_results_file(results_path)
         else:
             raise ValueError(
-                "results must be a FitResults object, str, or pathlib.Path"
+                "Expected a FitResults object, str, or pathlib.Path, "
+                f"but got {type(results)}. "
+                "Please specify a valid FitResults object or path to "
+                "a saved results file."
             )
         # Remove metrics like Rw from the dict, leaving only parameter values.
         # If a non-refinable quantity is ever stored as a tuple in the

--- a/src/diffpy/srfit/fitbase/fitrecipe.py
+++ b/src/diffpy/srfit/fitbase/fitrecipe.py
@@ -1486,7 +1486,7 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
         results_dict = FitResults._parse_results_text(text)
         return results_dict
 
-    def _prepare_result_for_initialization(self, results):
+    def _prepare_results_for_initialization(self, results):
         from diffpy.srfit.fitbase import FitResults
 
         if isinstance(results, FitResults):
@@ -1514,7 +1514,7 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
             be taken from the 'x' attribute of the FitResults object,
             which is the list of variable values at the best fit.
         """
-        parameters_dict = self._prepare_result_for_initialization(results)
+        parameters_dict = self._prepare_results_for_initialization(results)
         for name, (value, uncertainty) in parameters_dict.items():
             if name in self._parameters:
                 self._parameters[name].setValue(value)

--- a/src/diffpy/srfit/fitbase/fitresults.py
+++ b/src/diffpy/srfit/fitbase/fitresults.py
@@ -57,19 +57,20 @@ saveResults_dep_msg = build_deprecation_message(
     removal_version,
 )
 
-resultsDictionary_dep_msg = (
-    "'diffpy.srfit.fitbase.fitresults.resultsDictionary' is deprecated "
-    "and will be removed in version 4.0.0. Please use "
-    "'diffpy.srfit.fitbase.FitResults.get_results_dictionary' "
-    "instead."
+resultsDictionary_dep_msg = build_deprecation_message(
+    "diffpy.srfit.fitbase",
+    "resultsDictionary",
+    "get_results_dictionary",
+    removal_version,
+    new_base="diffpy.srfit.fitbase.FitResults",
 )
 
-
-initializeRecipe_dep_msg = (
-    "'diffpy.srfit.fitbase.initializeRecipe' is deprecated "
-    "and will be removed in version 4.0.0. Please use "
-    "'diffpy.srfit.fitbase.FitRecipe.initialize_recipe_from_results' "
-    "instead."
+initializeRecipe_dep_msg = build_deprecation_message(
+    "diffpy.srfit.fitbase",
+    "initializeRecipe",
+    "initialize_recipe_from_results",
+    removal_version,
+    new_base="diffpy.srfit.fitbase.FitRecipe",
 )
 
 

--- a/src/diffpy/srfit/fitbase/fitresults.py
+++ b/src/diffpy/srfit/fitbase/fitresults.py
@@ -39,7 +39,7 @@ removal_version = "4.0.0"
 formatResults_dep_msg = build_deprecation_message(
     fitresults_base,
     "formatResults",
-    "get_results_string",
+    "format_results_string",
     removal_version,
 )
 
@@ -57,11 +57,19 @@ saveResults_dep_msg = build_deprecation_message(
     removal_version,
 )
 
-resultsDictionary_dep_msg = build_deprecation_message(
-    "diffpy.srfit.fitbase.fitresults",
-    "resultsDictionary",
-    "FitResults.get_results_dictionary",
-    removal_version,
+resultsDictionary_dep_msg = (
+    "'diffpy.srfit.fitbase.fitresults.resultsDictionary' is deprecated "
+    "and will be removed in version 4.0.0. Please use "
+    "'diffpy.srfit.fitbase.FitResults.get_results_dictionary' "
+    "instead."
+)
+
+
+initializeRecipe_dep_msg = (
+    "'diffpy.srfit.fitbase.initializeRecipe' is deprecated "
+    "and will be removed in version 4.0.0. Please use "
+    "'diffpy.srfit.fitbase.FitRecipe.initialize_recipe_from_results' "
+    "instead."
 )
 
 
@@ -356,7 +364,7 @@ class FitResults(object):
             self.conunc.append(sig2c**0.5)
         return
 
-    def get_results_string(self, header="", footer="", update=False):
+    def format_results_string(self, header="", footer="", update=False):
         """Format the results and return them in a string.
 
         This function is called by print_results and save_results. Overloading
@@ -553,10 +561,10 @@ class FitResults(object):
         """This function has been deprecated and will be removed in version
         4.0.0.
 
-        Please use diffpy.srfit.fitbase.FitResults.get_results_string
+        Please use diffpy.srfit.fitbase.FitResults.format_results_string
         instead.
         """
-        return self.get_results_string(header, footer, update)
+        return self.format_results_string(header, footer, update)
 
     def print_results(self, header="", footer="", update=False):
         """Format and print the results.
@@ -570,7 +578,7 @@ class FitResults(object):
         update
             Flag indicating whether to call update() (default False).
         """
-        print(self.get_results_string(header, footer, update).rstrip())
+        print(self.format_results_string(header, footer, update).rstrip())
         return
 
     @deprecated(printResults_dep_msg)
@@ -585,7 +593,7 @@ class FitResults(object):
         return
 
     def __str__(self):
-        return self.get_results_string()
+        return self.format_results_string()
 
     def save_results(self, filename, header="", footer="", update=False):
         """Format and save the results.
@@ -609,7 +617,7 @@ class FitResults(object):
         myheader += "produced by " + getuser() + "\n"
         header = myheader + header
 
-        res = self.get_results_string(header, footer, update)
+        res = self.format_results_string(header, footer, update)
         f = open(filename, "w")
         f.write(res)
         f.close()
@@ -626,6 +634,48 @@ class FitResults(object):
         self.save_results(filename, header, footer, update)
         return
 
+    @staticmethod
+    def _parse_results_text(
+        text: str,
+    ) -> dict[str, float | tuple[float, float]]:
+        known_metrics = {
+            "Residual",
+            "Contributions",
+            "Restraints",
+            "Chi2",
+            "Reduced",
+            "Rw",
+        }
+        parsed_results_dict = {}
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if not line or set(line) == {"-"}:
+                continue
+            line_items = line.split()
+            if len(line_items) < 2:
+                continue
+            if line_items[0] == "Reduced" and len(line_items) >= 3:
+                try:
+                    parsed_results_dict["Reduced Chi2"] = float(line_items[2])
+                except ValueError:
+                    pass
+                continue
+            if line_items[0] in known_metrics:
+                try:
+                    parsed_results_dict[line_items[0]] = float(line_items[1])
+                except ValueError:
+                    pass
+                continue
+            if len(line_items) >= 4 and line_items[2] == "+/-":
+                try:
+                    parsed_results_dict[line_items[0]] = (
+                        float(line_items[1]),
+                        float(line_items[3]),
+                    )
+                except ValueError:
+                    pass
+        return parsed_results_dict
+
     def get_results_dictionary(self) -> dict[str, float | tuple[float, float]]:
         """Parse all numeric results from the results text.
 
@@ -637,53 +687,13 @@ class FitResults(object):
 
         Returns
         -------
-        parsed_results_dict : dict[str, float | tuple[float, float]]
+        results_dict : dict[str, float | tuple[float, float]]
             Dictionary mapping result names to numeric values. Entries with
             uncertainties are stored as ``(value, uncertainty)`` tuples.
         """
-        known_metrics = {
-            "Residual",
-            "Contributions",
-            "Restraints",
-            "Chi2",
-            "Reduced",
-            "Rw",
-        }
-        parsed_results_dict = {}
-        text = self.get_results_string()
-        for raw_line in text.splitlines():
-            line = raw_line.strip()
-            if not line or set(line) == {"-"}:
-                continue
-            line_items = line.split()
-            if len(line_items) < 2:
-                continue
-            if line_items[0] == "Reduced" and len(line_items) >= 3:
-                try:
-                    parsed_results_dict.update(
-                        {"Reduced Chi2": float(line_items[2])}
-                    )
-                except ValueError:
-                    pass
-                continue
-            if line_items[0] in known_metrics:
-                try:
-                    parsed_results_dict.update(
-                        {line_items[0]: float(line_items[1])}
-                    )
-                except ValueError:
-                    pass
-                continue
-            if len(line_items) >= 4 and line_items[2] == "+/-":
-                try:
-                    name = line_items[0]
-                    value = float(line_items[1])
-                    uncertainty = float(line_items[3])
-                    parsed_results_dict.update({name: (value, uncertainty)})
-                except ValueError:
-                    pass
-
-        return parsed_results_dict
+        text = self.format_results_string()
+        results_dict = self._parse_results_text(text)
+        return results_dict
 
 
 # End class FitResults
@@ -821,7 +831,7 @@ def resultsDictionary(results):
     """This function has been deprecated and will be removed in version 4.0.0.
 
     Please use diffpy.srfit.fitbase.FitResults.get_results_dictionary instead.
-    See ``Examples`` below for usage.
+    See ``Examples of new usage`` below for usage.
 
     Get dictionary of results from file.
 
@@ -834,8 +844,8 @@ def resultsDictionary(results):
         An open file-like object, name of a file that contains
         results from FitResults or a string containing fit results.
 
-    Examples
-    --------
+    Examples of new usage
+    ---------------------
     ::
 
         from diffpy.srfit.fitbase import FitResults, FitRecipe
@@ -859,8 +869,16 @@ def resultsDictionary(results):
     return mpairs
 
 
+@deprecated(initializeRecipe_dep_msg)
 def initializeRecipe(recipe, results):
-    """Initialize the variables of a recipe from a results file.
+    """This function has been deprecated and will be removed in version 4.0.0.
+
+    Please use
+    diffpy.srfit.fitbase.FitRecipe.initialize_recipe_from_results
+    instead.
+    For usage, see the ``Examples of new usage`` section below.
+
+    Initialize the variables of a recipe from a results file.
 
     This reads the results from file and initializes any variables (fixed or
     free) in the recipe to the results values. Note that the recipe has to be
@@ -873,6 +891,59 @@ def initializeRecipe(recipe, results):
     results
         An open file-like object, name of a file that contains
         results from FitResults or a string containing fit results.
+
+    Examples of new usage
+    ----------------------
+    How to use the new initialization method in ``FitRecipe``.
+
+    Initialize a new FitRecipe from a results file
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    ::
+
+        from diffpy.srfit.fitbase import FitRecipe, FitResults
+
+        new_recipe = FitRecipe("my_recipe")
+        new_recipe.create_new_variable("var1", 0)
+        new_recipe.create_new_variable("var2", 0)
+
+        # note: the variables in the new recipe (var1, var2) should match
+        # the variable names in the results file
+        path_to_results_file = "results.res"
+        new_recipe.initialize_recipe_from_results(path_to_results_file)
+
+    Initialize a FitRecipe from a FitResults object
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    ::
+
+        from diffpy.srfit.fitbase import FitRecipe, FitResults
+        from scipy.optimize import leastsq
+
+        def optimize_recipe(recipe):
+            residuals = recipe.residual
+            values = recipe.values
+            leastsq(residuals, values)
+
+
+        profile = Profile()
+        x = linspace(0, pi, 10)
+        y = sin(x)
+        profile.set_observed_profile(x, y)
+        contribution = FitContribution("c1")
+        contribution.set_profile(profile)
+        contribution.set_equation("amplitude*sin(wave_number*x + phase_shift)")
+        recipe = FitRecipe()
+        recipe.add_contribution(contribution)
+        recipe.add_variable(contribution.amplitude, 1)
+        recipe.add_variable(contribution.wave_number, 1)
+        recipe.add_variable(contribution.phase_shift, 1)
+        optimize_recipe(recipe)
+
+        results = FitResults(recipe)
+
+        new_recipe = FitRecipe("my_recipe")
+        new_recipe.initialize_recipe_from_results(results)
     """
     mpairs = resultsDictionary(results)
     if not mpairs:

--- a/src/diffpy/srfit/fitbase/fitresults.py
+++ b/src/diffpy/srfit/fitbase/fitresults.py
@@ -918,8 +918,11 @@ def initializeRecipe(recipe, results):
 
     ::
 
-        from diffpy.srfit.fitbase import FitRecipe, FitResults
         from scipy.optimize import leastsq
+        import numpy as np
+        from diffpy.srfit.fitbase import (
+            Profile, FitRecipe, FitResults, FitContribution
+            )
 
         def optimize_recipe(recipe):
             residuals = recipe.residual
@@ -928,8 +931,8 @@ def initializeRecipe(recipe, results):
 
 
         profile = Profile()
-        x = linspace(0, pi, 10)
-        y = sin(x)
+        x = np.linspace(0, np.pi, 10)
+        y = np.sin(x)
         profile.set_observed_profile(x, y)
         contribution = FitContribution("c1")
         contribution.set_profile(profile)
@@ -944,6 +947,10 @@ def initializeRecipe(recipe, results):
         results = FitResults(recipe)
 
         new_recipe = FitRecipe("my_recipe")
+        new_recipe.add_contribution(contribution)
+        new_recipe.add_variable(contribution.amplitude, 0)
+        new_recipe.add_variable(contribution.wave_number, 0)
+        new_recipe.add_variable(contribution.phase_shift, 0)
         new_recipe.initialize_recipe_from_results(results)
     """
     mpairs = resultsDictionary(results)

--- a/src/diffpy/srfit/fitbase/fitresults.py
+++ b/src/diffpy/srfit/fitbase/fitresults.py
@@ -635,48 +635,6 @@ class FitResults(object):
         self.save_results(filename, header, footer, update)
         return
 
-    @staticmethod
-    def _parse_results_text(
-        text: str,
-    ) -> dict[str, float | tuple[float, float]]:
-        known_metrics = {
-            "Residual",
-            "Contributions",
-            "Restraints",
-            "Chi2",
-            "Reduced",
-            "Rw",
-        }
-        parsed_results_dict = {}
-        for raw_line in text.splitlines():
-            line = raw_line.strip()
-            if not line or set(line) == {"-"}:
-                continue
-            line_items = line.split()
-            if len(line_items) < 2:
-                continue
-            if line_items[0] == "Reduced" and len(line_items) >= 3:
-                try:
-                    parsed_results_dict["Reduced Chi2"] = float(line_items[2])
-                except ValueError:
-                    pass
-                continue
-            if line_items[0] in known_metrics:
-                try:
-                    parsed_results_dict[line_items[0]] = float(line_items[1])
-                except ValueError:
-                    pass
-                continue
-            if len(line_items) >= 4 and line_items[2] == "+/-":
-                try:
-                    parsed_results_dict[line_items[0]] = (
-                        float(line_items[1]),
-                        float(line_items[3]),
-                    )
-                except ValueError:
-                    pass
-        return parsed_results_dict
-
     def get_results_dictionary(self) -> dict[str, float | tuple[float, float]]:
         """Parse all numeric results from the results text.
 
@@ -693,7 +651,7 @@ class FitResults(object):
             uncertainties are stored as ``(value, uncertainty)`` tuples.
         """
         text = self.format_results_string()
-        results_dict = self._parse_results_text(text)
+        results_dict = _parse_results_text(text)
         return results_dict
 
 
@@ -825,6 +783,48 @@ class ContributionResults(object):
 
 
 # End class ContributionResults
+
+
+def _parse_results_text(
+    text: str,
+) -> dict[str, float | tuple[float, float]]:
+    known_metrics = {
+        "Residual",
+        "Contributions",
+        "Restraints",
+        "Chi2",
+        "Reduced",
+        "Rw",
+    }
+    parsed_results_dict = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or set(line) == {"-"}:
+            continue
+        line_items = line.split()
+        if len(line_items) < 2:
+            continue
+        if line_items[0] == "Reduced" and len(line_items) >= 3:
+            try:
+                parsed_results_dict["Reduced Chi2"] = float(line_items[2])
+            except ValueError:
+                pass
+            continue
+        if line_items[0] in known_metrics:
+            try:
+                parsed_results_dict[line_items[0]] = float(line_items[1])
+            except ValueError:
+                pass
+            continue
+        if len(line_items) >= 4 and line_items[2] == "+/-":
+            try:
+                parsed_results_dict[line_items[0]] = (
+                    float(line_items[1]),
+                    float(line_items[3]),
+                )
+            except ValueError:
+                pass
+    return parsed_results_dict
 
 
 @deprecated(resultsDictionary_dep_msg)

--- a/src/diffpy/srfit/fitbase/fitresults.py
+++ b/src/diffpy/srfit/fitbase/fitresults.py
@@ -57,6 +57,13 @@ saveResults_dep_msg = build_deprecation_message(
     removal_version,
 )
 
+resultsDictionary_dep_msg = build_deprecation_message(
+    "diffpy.srfit.fitbase.fitresults",
+    "resultsDictionary",
+    "FitResults.get_results_dictionary",
+    removal_version,
+)
+
 
 class FitResults(object):
     """Class for processing, presenting and storing results of a fit.
@@ -619,6 +626,65 @@ class FitResults(object):
         self.save_results(filename, header, footer, update)
         return
 
+    def get_results_dictionary(self) -> dict[str, float | tuple[float, float]]:
+        """Parse all numeric results from the results text.
+
+        The method scans the entire results output and extracts all numeric
+        quantities. Two line formats are supported:
+
+        * ``name value`` → stored as a float
+        * ``name value +/- uncertainty`` → stored as ``(value, uncertainty)``
+
+        Returns
+        -------
+        parsed_results_dict : dict[str, float | tuple[float, float]]
+            Dictionary mapping result names to numeric values. Entries with
+            uncertainties are stored as ``(value, uncertainty)`` tuples.
+        """
+        known_metrics = {
+            "Residual",
+            "Contributions",
+            "Restraints",
+            "Chi2",
+            "Reduced",
+            "Rw",
+        }
+        parsed_results_dict = {}
+        text = self.get_results_string()
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if not line or set(line) == {"-"}:
+                continue
+            line_items = line.split()
+            if len(line_items) < 2:
+                continue
+            if line_items[0] == "Reduced" and len(line_items) >= 3:
+                try:
+                    parsed_results_dict.update(
+                        {"Reduced Chi2": float(line_items[2])}
+                    )
+                except ValueError:
+                    pass
+                continue
+            if line_items[0] in known_metrics:
+                try:
+                    parsed_results_dict.update(
+                        {line_items[0]: float(line_items[1])}
+                    )
+                except ValueError:
+                    pass
+                continue
+            if len(line_items) >= 4 and line_items[2] == "+/-":
+                try:
+                    name = line_items[0]
+                    value = float(line_items[1])
+                    uncertainty = float(line_items[3])
+                    parsed_results_dict.update({name: (value, uncertainty)})
+                except ValueError:
+                    pass
+
+        return parsed_results_dict
+
 
 # End class FitResults
 
@@ -750,8 +816,14 @@ class ContributionResults(object):
 # End class ContributionResults
 
 
+@deprecated(resultsDictionary_dep_msg)
 def resultsDictionary(results):
-    """Get dictionary of results from file.
+    """This function has been deprecated and will be removed in version 4.0.0.
+
+    Please use diffpy.srfit.fitbase.FitResults.get_results_dictionary instead.
+    See ``Examples`` below for usage.
+
+    Get dictionary of results from file.
 
     This reads the results from file and stores them in a dictionary to be
     returned to the caller. The dictionary may contain non-result entries.
@@ -761,6 +833,16 @@ def resultsDictionary(results):
     results
         An open file-like object, name of a file that contains
         results from FitResults or a string containing fit results.
+
+    Examples
+    --------
+    ::
+
+        from diffpy.srfit.fitbase import FitResults, FitRecipe
+
+        recipe = FitRecipe("my_recipe")
+        results = FitResults(recipe)
+        results_dict = results.get_results_dictionary()
     """
     resstr = inputToString(results)
 
@@ -792,7 +874,6 @@ def initializeRecipe(recipe, results):
         An open file-like object, name of a file that contains
         results from FitResults or a string containing fit results.
     """
-
     mpairs = resultsDictionary(results)
     if not mpairs:
         raise AttributeError("Cannot find results")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,7 +146,7 @@ def capturestdout():
     return _capturestdout
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def build_recipe_one_contribution():
     "helper to build a simple recipe"
     profile = Profile()
@@ -164,7 +164,7 @@ def build_recipe_one_contribution():
     return recipe
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def build_recipe_two_contributions():
     "helper to build a recipe with two contributions"
     profile1 = Profile()

--- a/tests/test_fitrecipe.py
+++ b/tests/test_fitrecipe.py
@@ -514,7 +514,12 @@ def test_initialize_recipe_bad(build_recipe_one_contribution):
     # Expected: ValueError is raised with message
     recipe = build_recipe_one_contribution
     bad_input = 12345  # not a FitResults object or a file path
-    msg = "results must be a FitResults object, str, or pathlib.Path"
+    msg = (
+        "Expected a FitResults object, str, or pathlib.Path, "
+        "but got <class 'int'>. "
+        "Please specify a valid FitResults object or path to "
+        "a saved results file."
+    )
     with pytest.raises(ValueError, match=msg):
         recipe.initialize_recipe_from_results(bad_input)
 

--- a/tests/test_fitrecipe.py
+++ b/tests/test_fitrecipe.py
@@ -22,8 +22,7 @@ import pytest
 from numpy import array_equal, dot, linspace, pi, sin
 from scipy.optimize import leastsq
 
-from diffpy.srfit.fitbase.fitcontribution import FitContribution
-from diffpy.srfit.fitbase.fitrecipe import FitRecipe
+from diffpy.srfit.fitbase import FitContribution, FitRecipe, FitResults
 from diffpy.srfit.fitbase.parameter import Parameter
 from diffpy.srfit.fitbase.profile import Profile
 from diffpy.srfit.pdf import PDFParser
@@ -297,6 +296,8 @@ class TestFitRecipe(unittest.TestCase):
 
 
 # ----------------------------------------------------------------------------
+
+
 def test_boundsToRestraints():
     recipe = FitRecipe("recipe")
 
@@ -460,6 +461,51 @@ def optimize_recipe(recipe):
     residuals = recipe.residual
     values = recipe.values
     leastsq(residuals, values)
+
+
+def test_initialize_recipe_from_results_object(build_recipe_one_contribution):
+    # Case: user optimizes recipe and then initializes a new recipe
+    #       with the FitResults object from that optimization
+    # Expected: new recipe has same variable values as original recipe
+    recipe_reference = build_recipe_one_contribution
+    optimize_recipe(recipe_reference)
+    results1 = FitResults(recipe_reference)
+
+    # build a new recipe and initialize it with the results from the
+    # first recipe
+    recipe_init = build_recipe_one_contribution
+    recipe_init.initialize_recipe_from_results(results1)
+
+    actual_var_names = recipe_init.get_names()
+    expected_var_names = recipe_reference.get_names()
+    actual_recipe_values = recipe_init.values
+    expected_recipe_values = recipe_reference.values
+    assert list(actual_recipe_values) == list(expected_recipe_values)
+    assert actual_var_names == expected_var_names
+
+
+def test_initialize_recipe_from_results_file(
+    build_recipe_one_contribution, tmp_path
+):
+    # Case: user optimizes recipe and saves it at a .res file,
+    #       then initializes a new recipe with that .res file
+    # Expected: new recipe has same variable values as original recipe
+    recipe_reference = build_recipe_one_contribution
+    optimize_recipe(recipe_reference)
+    results_reference = FitResults(recipe_reference)
+    results_reference.save_results(tmp_path / "results_reference.res")
+
+    recipe_init = build_recipe_one_contribution
+    recipe_init.initialize_recipe_from_results(
+        tmp_path / "results_reference.res"
+    )
+
+    actual_var_names = recipe_init.get_names()
+    expected_var_names = recipe_reference.get_names()
+    actual_recipe_values = recipe_init.values
+    expected_recipe_values = recipe_reference.values
+    assert list(actual_recipe_values) == list(expected_recipe_values)
+    assert actual_var_names == expected_var_names
 
 
 def get_labels_and_linecount(ax):

--- a/tests/test_fitrecipe.py
+++ b/tests/test_fitrecipe.py
@@ -508,6 +508,17 @@ def test_initialize_recipe_from_results_file(
     assert actual_var_names == expected_var_names
 
 
+def test_initialize_recipe_bad(build_recipe_one_contribution):
+    # Case: user tries to initialize recipe with something that is not a
+    #       FitResults object or a .res file
+    # Expected: ValueError is raised with message
+    recipe = build_recipe_one_contribution
+    bad_input = 12345  # not a FitResults object or a file path
+    msg = "results must be a FitResults object, str, or pathlib.Path"
+    with pytest.raises(ValueError, match=msg):
+        recipe.initialize_recipe_from_results(bad_input)
+
+
 def get_labels_and_linecount(ax):
     """Helper to get line labels and count from a matplotlib Axes."""
     labels = [

--- a/tests/test_fitresults.py
+++ b/tests/test_fitresults.py
@@ -65,11 +65,11 @@ def test_formatResults(build_recipe_one_contribution):
         assert expected_var in actual_results_string.strip()
 
 
-def test_get_results_string(build_recipe_one_contribution):
+def test_format_results_string(build_recipe_one_contribution):
     recipe = build_recipe_one_contribution
     optimize_recipe(recipe)
     results = FitResults(recipe)
-    actual_results_string = results.get_results_string(
+    actual_results_string = results.format_results_string(
         header="My Custom header"
     )
     # Because slight variations in refinement, just check

--- a/tests/test_fitresults.py
+++ b/tests/test_fitresults.py
@@ -138,6 +138,37 @@ def test_save_results(build_recipe_one_contribution, tmp_path):
         assert expected_var in actual_results.strip()
 
 
+def test_get_results_dictionary(build_recipe_one_contribution):
+    recipe = build_recipe_one_contribution
+    optimize_recipe(recipe)
+    results = FitResults(recipe)
+    results_dict = results.get_results_dictionary()
+    expected_results_dict = {
+        "Residual": 0.0,
+        "Contributions": 0.0,
+        "Restraints": 0.0,
+        "Chi2": 0.0,
+        "Reduced Chi2": 0.0,
+        "Rw": 0.0,
+        "amplitude": (1.0, 4.82804000e-01),
+        "phase_shift": (-1.61291146e-18, 1.00000000e00),
+        "wave_number": (1.00000000e00, 2.17496687e-01),
+    }
+    # iterate through and assert actual_key == expected_key
+    # and actual_value == expected_value (with approximation)
+    for expected_key, expected_value in expected_results_dict.items():
+        assert expected_key in results_dict
+        actual_value = results_dict.get(expected_key)
+        if isinstance(expected_value, tuple):
+            # If the expected value is a tuple, check each element with approx
+            assert len(actual_value) == len(expected_value)
+            for actual_val, expected_val in zip(actual_value, expected_value):
+                assert actual_val == pytest.approx(expected_val, rel=1e-3)
+        else:
+            # If the expected value is not a tuple, check with approx
+            assert actual_value == pytest.approx(expected_value, rel=1e-3)
+
+
 def testInitializeFromFileName(datafile):
     recipe = FitRecipe("recipe")
     recipe.create_new_variable("A", 0)

--- a/tests/test_fitresults.py
+++ b/tests/test_fitresults.py
@@ -20,7 +20,11 @@ import pytest
 from scipy.optimize import leastsq
 
 from diffpy.srfit.fitbase.fitrecipe import FitRecipe
-from diffpy.srfit.fitbase.fitresults import FitResults, initializeRecipe
+from diffpy.srfit.fitbase.fitresults import (
+    FitResults,
+    initializeRecipe,
+    resultsDictionary,
+)
 
 # The fit results from the recipe fixture in conftest.py
 expected_fitresults = """\
@@ -167,6 +171,34 @@ def test_get_results_dictionary(build_recipe_one_contribution):
         else:
             # If the expected value is not a tuple, check with approx
             assert actual_value == pytest.approx(expected_value, rel=1e-3)
+
+
+def test_resultsDictionary(build_recipe_one_contribution, tmp_path):
+    recipe = build_recipe_one_contribution
+    optimize_recipe(recipe)
+    results = FitResults(recipe)
+    results.save_results(
+        tmp_path / "fit_results.txt", header="My Custom header"
+    )
+    actual_results_dict = resultsDictionary(str(tmp_path / "fit_results.txt"))
+    expected_results_dict_keys = [
+        "than",  # bad behavior: shouldn't be here
+        "Feb",  # bad behavior: shouldn't be here
+        "Residual",
+        # "Reduced Chi2", # bad behavior: should be here but is not
+        "Contributions",
+        "Restraints",
+        "Chi2",
+        "Rw",
+        "amplitude",
+        "phase_shift",
+        "wave_number",
+    ]
+    # get list of keys from actual_results_dict and check
+    # that all expected keys are in it
+    assert sorted(expected_results_dict_keys) == sorted(
+        list(actual_results_dict.keys())
+    )
 
 
 def testInitializeFromFileName(datafile):

--- a/tests/test_fitresults.py
+++ b/tests/test_fitresults.py
@@ -167,10 +167,10 @@ def test_get_results_dictionary(build_recipe_one_contribution):
             # If the expected value is a tuple, check each element with approx
             assert len(actual_value) == len(expected_value)
             for actual_val, expected_val in zip(actual_value, expected_value):
-                assert actual_val == pytest.approx(expected_val, rel=1e-3)
+                assert round(actual_val, 3) == round(expected_val, 3)
         else:
             # If the expected value is not a tuple, check with approx
-            assert actual_value == pytest.approx(expected_value, rel=1e-3)
+            assert round(actual_value, 3) == round(expected_value, 3)
 
 
 def test_resultsDictionary(build_recipe_one_contribution, tmp_path):


### PR DESCRIPTION
These changes are,

`diffpy.srfit.fitbase.initializeResults` --> `diffpy.srfit.fitbase.FitRecipe.initialize_recipe_from_results`
`diffpy.srfit.fitbase.resultsDictionary` --> `diffpy.srfit.fitbase.FitResults.get_results_dictionary`

I remember we talked about this at ADD. It was challenging to actually find these function so i think their new homes makes sense. 

### Initializing a recipe with a results

This can be done with a results object,
```
results = FitResults(<pre-existing recipe>)

recipe = FitRecipe("my_recipe")
recipe.initialize_recipe_from_results(results)
```

or a results file,

```
recipe = FitRecipe("my_recipe")
recipe.initialize_recipe_from_results(Path("path/to/results.res"))
```

### Getting results dictionary

Now, all the user has to do to get the refined parameters and the associated uncertainties is,

```
results = FitResults(recipe)

params_dict = results.get_results_dictionary()
```


