### PR TITLE
Deprecate: deprecate all methods of `parameters.py`

### DIFF
--- a/news/param-dep.rst
+++ b/news/param-dep.rst
@@ -1,0 +1,27 @@
+**Added:**
+
+* Added ``is_constant`` method to ``Parameter``.
+* Added ``bound_range`` method to ``Parameter``.
+* Added ``bound_window`` method to ``Parameter``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* Deprecated ``isConst`` method of ``Parameter``. Use ``is_constant`` instead.
+* Deprecated ``boundRange`` method of ``Parameter``. Use ``bound_range`` instead.
+* Deprecated ``boundWindow`` method of ``Parameter``. Use ``bound_window`` instead.
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/srfit/equation/builder.py
+++ b/src/diffpy/srfit/equation/builder.py
@@ -493,7 +493,7 @@ class BaseBuilder(object):
 
         Other can be an BaseBuilder or a constant.
 
-        Attributes
+        Parameters
         ----------
         onleft
             Indicates that the operator was passed on the left side
@@ -666,7 +666,7 @@ class OperatorBuilder(BaseBuilder):
 
         This creates a new builder that encapsulates the operation.
 
-        Attributes
+        Parameters
         ----------
         args
             Arguments of the operation.
@@ -730,7 +730,7 @@ def wrapOperator(name, op):
 def wrapFunction(name, func, nin=2, nout=1):
     """Wrap a function in an OperatorBuilder instance.
 
-    Attributes
+    Parameters
     ----------
     name
         The name of the function

--- a/src/diffpy/srfit/equation/equationmod.py
+++ b/src/diffpy/srfit/equation/equationmod.py
@@ -91,7 +91,7 @@ class Equation(Operator):
     def __init__(self, name=None, root=None):
         """Initialize.
 
-        Attributes
+        Parameters
         ----------
         name
             A name for this Equation.

--- a/src/diffpy/srfit/equation/literals/argument.py
+++ b/src/diffpy/srfit/equation/literals/argument.py
@@ -62,7 +62,7 @@ class Argument(Literal, ArgumentABC):
     def set_value(self, val):
         """Set the value of the Literal.
 
-        Attributes
+        Parameters
         ----------
         val
             The value to assign

--- a/src/diffpy/srfit/equation/literals/operators.py
+++ b/src/diffpy/srfit/equation/literals/operators.py
@@ -347,7 +347,7 @@ class UFuncOperator(Operator):
 
         Arguments
 
-        Attributes
+        Parameters
         ----------
         op
             A numpy ufunc

--- a/src/diffpy/srfit/equation/visitors/__init__.py
+++ b/src/diffpy/srfit/equation/visitors/__init__.py
@@ -35,7 +35,7 @@ from diffpy.srfit.equation.visitors.validator import Validator
 def getArgs(literal, getconsts=True):
     """Get the Arguments of a Literal tree.
 
-    Attributes
+    Parameters
     ----------
     getconsts
         If True (default), then Arguments designated as constant
@@ -50,7 +50,7 @@ def getArgs(literal, getconsts=True):
 def getExpression(literal, eqskip=None):
     """Get math expression string from the Literal tree object.
 
-    Attributes
+    Parameters
     ----------
     eqskip
         regular expression pattern for Equation objects that should

--- a/src/diffpy/srfit/equation/visitors/printer.py
+++ b/src/diffpy/srfit/equation/visitors/printer.py
@@ -29,8 +29,6 @@ from diffpy.srfit.equation.visitors.visitor import Visitor
 class Printer(Visitor):
     """Printer for printing a Literal tree.
 
-    Attributes:
-
     Attributes
     ----------
     eqskip

--- a/src/diffpy/srfit/equation/visitors/swapper.py
+++ b/src/diffpy/srfit/equation/visitors/swapper.py
@@ -38,7 +38,7 @@ class Swapper(Visitor):
     def __init__(self, oldlit, newlit):
         """Initialize.
 
-        Attributes
+        Parameters
         ----------
         oldlit
             The literal to be replaced.

--- a/src/diffpy/srfit/fitbase/fitcontribution.py
+++ b/src/diffpy/srfit/fitbase/fitcontribution.py
@@ -147,7 +147,7 @@ class FitContribution(ParameterSet):
     def set_profile(self, profile, xname=None, yname=None, dyname=None):
         """Assign the Profile for this FitContribution.
 
-        Attributes
+        Parameters
         ----------
         profile
             A Profile that specifies the calculation points and that
@@ -227,7 +227,7 @@ class FitContribution(ParameterSet):
         Calling addProfileGenerator sets the profile equation to call the
         calculator and if there is not a profile equation already.
 
-        Attributes
+        Parameters
         ----------
         gen
             A ProfileGenerator instance
@@ -278,7 +278,7 @@ class FitContribution(ParameterSet):
         for this FitContribution.  The equation will be usable within
         set_residual_equation as "eq", and it takes no arguments.
 
-        Attributes
+        Parameters
         ----------
         eqstr
             A string representation of the equation. Any Parameter
@@ -353,7 +353,7 @@ class FitContribution(ParameterSet):
     def set_residual_equation(self, eqstr):
         """Set the residual equation for the FitContribution.
 
-        Attributes
+        Parameters
         ----------
         eqstr
             A string representation of the residual. If eqstr is None

--- a/src/diffpy/srfit/fitbase/fithook.py
+++ b/src/diffpy/srfit/fitbase/fithook.py
@@ -58,7 +58,7 @@ class FitHook(object):
         """This is called within FitRecipe.residual, before the
         calculation.
 
-        Attributes
+        Parameters
         ----------
         recipe
             The FitRecipe instance
@@ -69,7 +69,7 @@ class FitHook(object):
         """This is called within FitRecipe.residual, after the
         calculation.
 
-        Attributes
+        Parameters
         ----------
         recipe
             The FitRecipe instance
@@ -87,8 +87,6 @@ class PrintFitHook(FitHook):
 
     This FitHook prints out a running count of the number of times the residual
     has been called, or other information, based on the verbosity.
-
-    Attributes
 
     Attributes
     ----------
@@ -127,7 +125,7 @@ class PrintFitHook(FitHook):
         """This is called within FitRecipe.residual, before the
         calculation.
 
-        Attributes
+        Parameters
         ----------
         recipe
             The FitRecipe instance
@@ -141,7 +139,7 @@ class PrintFitHook(FitHook):
         """This is called within FitRecipe.residual, after the
         calculation.
 
-        Attributes
+        Parameters
         ----------
         recipe
             The FitRecipe instance
@@ -237,7 +235,7 @@ class PlotFitHook(FitHook):
 
         Find data and plot it.
 
-        Attributes
+        Parameters
         ----------
         recipe
             The FitRecipe instance

--- a/src/diffpy/srfit/fitbase/fitrecipe.py
+++ b/src/diffpy/srfit/fitbase/fitrecipe.py
@@ -906,7 +906,7 @@ class FitRecipe(_fitrecipe_interface, RecipeOrganizer):
     def __get_var_and_check(self, var):
         """Get the actual variable from var.
 
-        Attributes
+        Parameters
         ----------
         var
             A variable of the FitRecipe, or the name of a variable.

--- a/src/diffpy/srfit/fitbase/fitresults.py
+++ b/src/diffpy/srfit/fitbase/fitresults.py
@@ -162,7 +162,7 @@ class FitResults(object):
     def __init__(self, recipe, update=True, showfixed=True, showcon=False):
         """Initialize the attributes.
 
-        Attributes
+        Parameters
         ----------
         recipe : FitRecipe
             The recipe containing the results.
@@ -733,7 +733,7 @@ class ContributionResults(object):
     def __init__(self, con, weight, fitres):
         """Initialize the attributes.
 
-        Attributes
+        Parameters
         ----------
         con
             The FitContribution
@@ -829,7 +829,7 @@ def resultsDictionary(results):
     This reads the results from file and stores them in a dictionary to be
     returned to the caller. The dictionary may contain non-result entries.
 
-    Attributes
+    Parameters
     ----------
     results
         An open file-like object, name of a file that contains
@@ -865,7 +865,7 @@ def initializeRecipe(recipe, results):
     free) in the recipe to the results values. Note that the recipe has to be
     configured, with variables. This does not reconstruct a FitRecipe.
 
-    Attributes
+    Parameters
     ----------
     recipe
         A configured recipe with variables

--- a/src/diffpy/srfit/fitbase/parameter.py
+++ b/src/diffpy/srfit/fitbase/parameter.py
@@ -50,6 +50,10 @@ boundRange_dep_msg = build_deprecation_message(
     parameter_base, "boundRange", "bound_range", removal_version
 )
 
+boundWindow_dep_msg = build_deprecation_message(
+    parameter_base, "boundWindow", "bound_window", removal_version
+)
+
 
 class Parameter(_parameter_interface, Argument, Validatable):
     """Parameter class.
@@ -191,18 +195,18 @@ class Parameter(_parameter_interface, Argument, Validatable):
         self.bound_range(lower_bound, upper_bound)
         return self
 
-    def boundWindow(self, lr=0, ur=None):
+    def bound_window(self, lower_radius=0, upper_radius=None):
         """Create bounds centered on the current value of the Parameter.
 
         Parameters
         ----------
-        lr
+        lower_radius : float, optional
             The radius of the lower bound (default 0). The lower bound is
-            computed as value - lr.
-        ur
+            computed as value - lower_radius.
+        upper_radius : float, optional
             The radius of the upper bound. The upper bound is computed as
-            value + ur. If this is None (default), then the value of the
-            lower radius is used.
+            value + upper_radius. If this is None (default), then the value
+            of the lower radius is used.
 
         Returns
         -------
@@ -210,11 +214,21 @@ class Parameter(_parameter_interface, Argument, Validatable):
             Returns self so that mutators can be chained.
         """
         val = self.getValue()
-        lower_bound = val - lr
-        if ur is None:
-            ur = lr
-        upper_bound = val + ur
+        lower_bound = val - lower_radius
+        if upper_radius is None:
+            upper_radius = lower_radius
+        upper_bound = val + upper_radius
         self.bounds = [lower_bound, upper_bound]
+        return self
+
+    @deprecated(boundWindow_dep_msg)
+    def boundWindow(self, lr=0, ur=None):
+        """This function has been deprecated and will be removed in
+        version 4.0.0.
+
+        Please use diffpy.srfit.fitbase.Parameter.bound_window instead.
+        """
+        self.bound_window(lr, ur)
         return self
 
     def _validate(self):
@@ -314,9 +328,9 @@ class ParameterProxy(Parameter):
     def bound_range(self, lower_bound=None, upper_bound=None):
         return self.par.bound_range(lower_bound, upper_bound)
 
-    @wraps(Parameter.boundWindow)
-    def boundWindow(self, lr=0, ur=None):
-        return self.par.boundWindow(lr, ur)
+    @wraps(Parameter.bound_window)
+    def bound_window(self, lr=0, ur=None):
+        return self.par.bound_window(lr, ur)
 
     def _validate(self):
         """Validate my state.

--- a/src/diffpy/srfit/fitbase/parameter.py
+++ b/src/diffpy/srfit/fitbase/parameter.py
@@ -42,6 +42,10 @@ setValue_dep_msg = build_deprecation_message(
     parameter_base, "setValue", "set_value", removal_version
 )
 
+setConst_dep_msg = build_deprecation_message(
+    parameter_base, "setConst", "set_constant", removal_version
+)
+
 
 class Parameter(_parameter_interface, Argument, Validatable):
     """Parameter class.
@@ -119,17 +123,17 @@ class Parameter(_parameter_interface, Argument, Validatable):
         """
         return self.set_value(val)
 
-    def setConst(self, const=True, value=None):
+    def set_constant(self, is_constant=True, value=None):
         """Toggle the Parameter as constant.
 
-        Attributes
+        Parameters
         ----------
-        const
-            Flag indicating if the parameter is constant (default
+        is_constant : bool, optional
+            The flag indicating if the parameter is constant (default
             True).
-        value
-            An optional value for the parameter (default None). If this
-            is not None, then the parameter will get a new value,
+        value : float, optional
+            The value value for the parameter to be set to (default None).
+            If this is not None, then the parameter will get a new value,
             constant or otherwise.
 
         Returns
@@ -137,9 +141,19 @@ class Parameter(_parameter_interface, Argument, Validatable):
         self
             Returns self so that mutators can be chained.
         """
-        self.const = bool(const)
+        self.const = bool(is_constant)
         if value is not None:
             self.set_value(value)
+        return self
+
+    @deprecated(setConst_dep_msg)
+    def setConst(self, const=True, value=None):
+        """This function has been deprecated and will be removed in
+        version 4.0.0.
+
+        Please use diffpy.srfit.fitbase.Parameter.set_constant instead.
+        """
+        self.set_constant(const, value)
         return self
 
     def boundRange(self, lower_bound=None, upper_bound=None):
@@ -278,9 +292,9 @@ class ParameterProxy(Parameter):
     def getValue(self):
         return self.par.getValue()
 
-    @wraps(Parameter.setConst)
-    def setConst(self, const=True, value=None):
-        return self.par.setConst(const, value)
+    @wraps(Parameter.set_constant)
+    def set_constant(self, const=True, value=None):
+        return self.par.set_constant(const, value)
 
     @wraps(Parameter.boundRange)
     def boundRange(self, lower_bound=None, upper_bound=None):

--- a/src/diffpy/srfit/fitbase/parameter.py
+++ b/src/diffpy/srfit/fitbase/parameter.py
@@ -46,6 +46,10 @@ setConst_dep_msg = build_deprecation_message(
     parameter_base, "setConst", "set_constant", removal_version
 )
 
+boundRange_dep_msg = build_deprecation_message(
+    parameter_base, "boundRange", "bound_range", removal_version
+)
+
 
 class Parameter(_parameter_interface, Argument, Validatable):
     """Parameter class.
@@ -156,7 +160,7 @@ class Parameter(_parameter_interface, Argument, Validatable):
         self.set_constant(const, value)
         return self
 
-    def boundRange(self, lower_bound=None, upper_bound=None):
+    def bound_range(self, lower_bound=None, upper_bound=None):
         """Set lower and upper bound of the Parameter.
 
         Parameters
@@ -175,6 +179,16 @@ class Parameter(_parameter_interface, Argument, Validatable):
             self.bounds[0] = lower_bound
         if upper_bound is not None:
             self.bounds[1] = upper_bound
+        return self
+
+    @deprecated(boundRange_dep_msg)
+    def boundRange(self, lower_bound=None, upper_bound=None):
+        """This function has been deprecated and will be removed in
+        version 4.0.0.
+
+        Please use diffpy.srfit.fitbase.Parameter.bound_range instead.
+        """
+        self.bound_range(lower_bound, upper_bound)
         return self
 
     def boundWindow(self, lr=0, ur=None):
@@ -296,9 +310,9 @@ class ParameterProxy(Parameter):
     def set_constant(self, const=True, value=None):
         return self.par.set_constant(const, value)
 
-    @wraps(Parameter.boundRange)
-    def boundRange(self, lower_bound=None, upper_bound=None):
-        return self.par.boundRange(lower_bound, upper_bound)
+    @wraps(Parameter.bound_range)
+    def bound_range(self, lower_bound=None, upper_bound=None):
+        return self.par.bound_range(lower_bound, upper_bound)
 
     @wraps(Parameter.boundWindow)
     def boundWindow(self, lr=0, ur=None):

--- a/src/diffpy/srfit/fitbase/parameter.py
+++ b/src/diffpy/srfit/fitbase/parameter.py
@@ -72,7 +72,7 @@ class Parameter(_parameter_interface, Argument, Validatable):
     def __init__(self, name, value=None, const=False):
         """Initialization.
 
-        Attributes
+        Parameters
         ----------
         name
             The name of this Parameter (must be a valid attribute
@@ -95,7 +95,7 @@ class Parameter(_parameter_interface, Argument, Validatable):
     def set_value(self, val):
         """Set the value of the Parameter and the bounds.
 
-        Attributes
+        Parameters
         ----------
         val
             The value to assign.
@@ -159,7 +159,7 @@ class Parameter(_parameter_interface, Argument, Validatable):
     def boundRange(self, lower_bound=None, upper_bound=None):
         """Set lower and upper bound of the Parameter.
 
-        Attributes
+        Parameters
         ----------
         lower_bound : float
             The lower bound for the bounds list.
@@ -180,7 +180,7 @@ class Parameter(_parameter_interface, Argument, Validatable):
     def boundWindow(self, lr=0, ur=None):
         """Create bounds centered on the current value of the Parameter.
 
-        Attributes
+        Parameters
         ----------
         lr
             The radius of the lower bound (default 0). The lower bound is
@@ -235,7 +235,7 @@ class ParameterProxy(Parameter):
     def __init__(self, name, par):
         """Initialization.
 
-        Attributes
+        Parameters
         ----------
         name
             The name of this ParameterProxy.
@@ -330,7 +330,7 @@ class ParameterAdapter(Parameter):
     def __init__(self, name, obj, getter=None, setter=None, attr=None):
         """Wrap an object as a Parameter.
 
-        Attributes
+        Parameters
         ----------
         name
             The name of this Parameter.

--- a/src/diffpy/srfit/fitbase/parameterset.py
+++ b/src/diffpy/srfit/fitbase/parameterset.py
@@ -87,7 +87,7 @@ class ParameterSet(RecipeOrganizer):
     def __init__(self, name):
         """Initialize.
 
-        Attributes
+        Parameters
         ----------
         name
             The name of this ParameterSet.
@@ -106,7 +106,7 @@ class ParameterSet(RecipeOrganizer):
     def add_parameter_set(self, parset):
         """Add a ParameterSet to the hierarchy.
 
-        Attributes
+        Parameters
         ----------
         parset
             The ParameterSet to be stored.
@@ -154,7 +154,7 @@ class ParameterSet(RecipeOrganizer):
     def set_constant(self, is_constant=True):
         """Set every parameter within the set to a constant.
 
-        Attributes
+        Parameters
         ----------
         is_constant : bool, optional
             The flag indicating if the parameter is constant (default

--- a/src/diffpy/srfit/fitbase/parameterset.py
+++ b/src/diffpy/srfit/fitbase/parameterset.py
@@ -38,6 +38,10 @@ removeParameterSet_dep_msg = build_deprecation_message(
     base, "removeParameterSet", "remove_parameter_set", removal_version
 )
 
+setConst_dep_msg = build_deprecation_message(
+    base, "setConst", "set_constant", removal_version
+)
+
 
 class ParameterSet(RecipeOrganizer):
     """Class for organizing Parameters and other ParameterSets.
@@ -147,18 +151,29 @@ class ParameterSet(RecipeOrganizer):
         self.remove_parameter_set(parset)
         return
 
-    def setConst(self, const=True):
+    def set_constant(self, is_constant=True):
         """Set every parameter within the set to a constant.
 
         Attributes
         ----------
-        const
-            Flag indicating if the parameter is constant (default
+        is_constant : bool, optional
+            The flag indicating if the parameter is constant (default
             True).
         """
         for par in self.iterate_over_parameters():
-            par.setConst(const)
+            par.set_constant(is_constant)
+        return
 
+    @deprecated(setConst_dep_msg)
+    def setConst(self, const=True):
+        """This function has been deprecated and will be removed in
+        version 4.0.0.
+
+        Please use
+        diffpy.srfit.fitbase.parameterset.ParameterSet.set_constant
+        instead.
+        """
+        self.set_constant(const)
         return
 
 

--- a/src/diffpy/srfit/fitbase/profile.py
+++ b/src/diffpy/srfit/fitbase/profile.py
@@ -72,8 +72,6 @@ class Profile(Observable, Validatable):
     by the Profile, which can in turn be observed by some other object.
 
     Attributes
-
-    Attributes
     ----------
     _xobs
         A numpy array of the observed independent variable (default

--- a/src/diffpy/srfit/fitbase/profilegenerator.py
+++ b/src/diffpy/srfit/fitbase/profilegenerator.py
@@ -156,7 +156,7 @@ class ProfileGenerator(Operator, ParameterSet):
     def set_profile(self, profile):
         """Assign the profile.
 
-        Attributes
+        Parameters
         ----------
         profile
             A Profile that specifies the calculation points and which

--- a/src/diffpy/srfit/fitbase/profilegenerator.py
+++ b/src/diffpy/srfit/fitbase/profilegenerator.py
@@ -171,10 +171,10 @@ class ProfileGenerator(Operator, ParameterSet):
 
         # Merge the profiles metadata with our own
         self.meta.update(self.profile.meta)
-        self.processMetaData()
+        self._process_metadata()
         return
 
-    def processMetaData(self):
+    def _process_metadata(self):
         """Process the metadata.
 
         This can be used to configure a ProfileGenerator upon a change

--- a/src/diffpy/srfit/fitbase/recipeorganizer.py
+++ b/src/diffpy/srfit/fitbase/recipeorganizer.py
@@ -413,7 +413,7 @@ class RecipeContainer(Observable, Configurable, Validatable):
     def _add_object(self, obj, d, check=True):
         """Add an object to a managed dictionary.
 
-        Attributes
+        Parameters
         ----------
         obj
             The object to be stored.
@@ -482,7 +482,7 @@ class RecipeContainer(Observable, Configurable, Validatable):
     def _locate_managed_object(self, obj):
         """Find the location a managed object within the hierarchy.
 
-        Attributes
+        Parameters
         ----------
         obj
             The object to find.
@@ -610,7 +610,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
 
         Parameters added in this way are registered with the _eqfactory.
 
-        Attributes
+        Parameters
         ----------
         parameter
             The Parameter to be stored.
@@ -657,7 +657,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
         arguments like a function or without, in which case the values of the
         Parameters created from argnames will be be used to compute the value.
 
-        Attributes
+        Parameters
         ----------
         calculator : Calculator object
             The Calculator to register.
@@ -1047,7 +1047,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
 
         This removes any constraints on a Parameter.
 
-        Attributes
+        Parameters
         ----------
         *pars : str or Parameter
             The names of Parameters or Parameters to unconstrain.
@@ -1114,7 +1114,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
     def getConstrainedPars(self, recurse=False):
         """Get a list of constrained managed Parameters in this object.
 
-        Attributes
+        Parameters
         ----------
         recurse
             Recurse into managed objects and retrieve their constrained
@@ -1294,7 +1294,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
     def remove_soft_bounds(self, *ress):
         """Remove a Restraint from the RecipeOrganizer.
 
-        Attributes
+        Parameters
         ----------
         *ress : Restraint
             The Restraints returned from the 'add_soft_bounds' method or added
@@ -1328,7 +1328,7 @@ class RecipeOrganizer(_recipeorganizer_interface, RecipeContainer):
     def clear_all_soft_bounds(self, recurse=False):
         """Clear all restraints.
 
-        Attributes
+        Parameters
         ----------
         recurse
             Recurse into managed objects and clear all restraints
@@ -1543,7 +1543,7 @@ def get_equation_from_string(
 ):
     """Make an Equation object from a string.
 
-    Attributes
+    Parameters
     ----------
     eqstr : str
         A string representation of the equation. The equation must

--- a/src/diffpy/srfit/fitbase/restraint.py
+++ b/src/diffpy/srfit/fitbase/restraint.py
@@ -59,7 +59,7 @@ class Restraint(Validatable):
     ):
         """Restrain an equation to specified bounds.
 
-        Attributes
+        Parameters
         ----------
         eq
             An equation whose evaluation is compared against the
@@ -87,7 +87,7 @@ class Restraint(Validatable):
     def penalty(self, w=1.0):
         """Calculate the penalty of the restraint.
 
-        Attributes
+        Parameters
         ----------
         w
             The point-average chi^2 which is optionally used to scale the

--- a/src/diffpy/srfit/fitbase/simplerecipe.py
+++ b/src/diffpy/srfit/fitbase/simplerecipe.py
@@ -306,7 +306,7 @@ class SimpleRecipe(FitRecipe):
         The equation will be usable within set_residual_equation as "eq", and
         it takes no arguments.
 
-        Attributes
+        Parameters
         ----------
         eqstr
             A string representation of the equation. Variables will be
@@ -352,7 +352,7 @@ class SimpleRecipe(FitRecipe):
     def print_results(self, header="", footer=""):
         """Format and print the results.
 
-        Attributes
+        Parameters
         ----------
         header
             A header to add to the output (default "")

--- a/src/diffpy/srfit/interface/interface.py
+++ b/src/diffpy/srfit/interface/interface.py
@@ -40,7 +40,7 @@ class ParameterInterface(object):
 
         Think of '<<' as injecting a value
 
-        Attributes
+        Parameters
         ----------
         v
             value or Argument derivative

--- a/src/diffpy/srfit/interface/interface.py
+++ b/src/diffpy/srfit/interface/interface.py
@@ -40,7 +40,7 @@ class ParameterInterface(object):
 
         Think of '<<' as injecting a value
 
-        Parameters
+        Attributes
         ----------
         v
             value or Argument derivative

--- a/src/diffpy/srfit/pdf/basepdfgenerator.py
+++ b/src/diffpy/srfit/pdf/basepdfgenerator.py
@@ -117,7 +117,7 @@ class BasePDFGenerator(ProfileGenerator):
         self._calc = calc
         for pname in self.__class__._parnames:
             self.addParameter(ParameterAdapter(pname, self._calc, attr=pname))
-        self.processMetaData()
+        self._process_metadata()
         return
 
     def parallel(self, ncpu, mapfunc=None):
@@ -154,9 +154,9 @@ class BasePDFGenerator(ProfileGenerator):
         self._calc = createParallelCalculator(calc_serial, ncpu, mapfunc)
         return
 
-    def processMetaData(self):
+    def _process_metadata(self):
         """Process the metadata once it gets set."""
-        ProfileGenerator.processMetaData(self)
+        ProfileGenerator._process_metadata(self)
 
         stype = self.meta.get("stype")
         if stype is not None:

--- a/src/diffpy/srfit/pdf/basepdfgenerator.py
+++ b/src/diffpy/srfit/pdf/basepdfgenerator.py
@@ -123,7 +123,7 @@ class BasePDFGenerator(ProfileGenerator):
     def parallel(self, ncpu, mapfunc=None):
         """Run calculation in parallel.
 
-        Attributes
+        Parameters
         ----------
         ncpu
             Number of parallel processes.  Revert to serial mode when 1.
@@ -181,7 +181,7 @@ class BasePDFGenerator(ProfileGenerator):
     def setScatteringType(self, stype="X"):
         """Set the scattering type.
 
-        Attributes
+        Parameters
         ----------
         stype
             "X" for x-ray, "N" for neutron, "E" for electrons,
@@ -230,7 +230,7 @@ class BasePDFGenerator(ProfileGenerator):
         See those classes (located in diffpy.srfit.structure) for how they are
         used. The resulting ParameterSet will be managed by this generator.
 
-        Attributes
+        Parameters
         ----------
         stru
             diffpy.structure.Structure, pyobjcryst.crystal.Crystal or
@@ -260,7 +260,7 @@ class BasePDFGenerator(ProfileGenerator):
         object (from diffpy or pyobjcryst).  The passed ParameterSet will be
         managed by this generator.
 
-        Attributes
+        Parameters
         ----------
         parset
             A SrRealParSet that holds the structural information.

--- a/src/diffpy/srfit/pdf/characteristicfunctions.py
+++ b/src/diffpy/srfit/pdf/characteristicfunctions.py
@@ -48,7 +48,7 @@ from diffpy.srfit.fitbase.calculator import Calculator
 def sphericalCF(r, psize):
     """Spherical nanoparticle characteristic function.
 
-    Attributes
+    Parameters
     ----------
     r
         distance of interaction
@@ -73,7 +73,7 @@ def spheroidalCF(r, erad, prad):
 
     Spheroid with radii (erad, erad, prad)
 
-    Attributes
+    Parameters
     ----------
     prad
         polar radius
@@ -95,7 +95,7 @@ def spheroidalCF2(r, psize, axrat):
 
     Form factor for ellipsoid with radii (psize/2, psize/2, axrat*psize/2)
 
-    Attributes
+    Parameters
     ----------
     r
         distance of interaction
@@ -206,7 +206,7 @@ def lognormalSphericalCF(r, psize, psig):
     """Spherical nanoparticle characteristic function with lognormal
     size distribution.
 
-    Attributes
+    Parameters
     ----------
     r
         distance of interaction
@@ -263,7 +263,7 @@ def lognormalSphericalCF(r, psize, psig):
 def sheetCF(r, sthick):
     """Nanosheet characteristic function.
 
-    Attributes
+    Parameters
     ----------
     r
         distance of interaction
@@ -293,7 +293,7 @@ def sheetCF(r, sthick):
 def shellCF(r, radius, thickness):
     """Spherical shell characteristic function.
 
-    Attributes
+    Parameters
     ----------
     radius
         Inner radius
@@ -313,7 +313,7 @@ def shellCF(r, radius, thickness):
 def shellCF2(r, a, delta):
     """Spherical shell characteristic function.
 
-    Attributes
+    Parameters
     ----------
     a
         Central radius
@@ -378,7 +378,7 @@ class SASCF(Calculator):
     def __init__(self, name, model):
         """Initialize the generator.
 
-        Attributes
+        Parameters
         ----------
         name
             A name for the SASCF

--- a/src/diffpy/srfit/pdf/debyepdfgenerator.py
+++ b/src/diffpy/srfit/pdf/debyepdfgenerator.py
@@ -92,7 +92,7 @@ class DebyePDFGenerator(BasePDFGenerator):
         See those classes (located in diffpy.srfit.structure) for how they are
         used. The resulting ParameterSet will be managed by this generator.
 
-        Attributes
+        Parameters
         ----------
         stru
             diffpy.structure.Structure, pyobjcryst.crystal.Crystal or
@@ -116,7 +116,7 @@ class DebyePDFGenerator(BasePDFGenerator):
         object (from diffpy or pyobjcryst).  The passed ParameterSet will be
         managed by this generator.
 
-        Attributes
+        Parameters
         ----------
         parset
             A SrRealParSet that holds the structural information.

--- a/src/diffpy/srfit/pdf/pdfcontribution.py
+++ b/src/diffpy/srfit/pdf/pdfcontribution.py
@@ -284,7 +284,7 @@ class PDFContribution(FitContribution):
 
         # Update with our metadata
         gen.meta.update(self._meta)
-        gen.processMetaData()
+        gen._process_metadata()
 
         # Constrain the shared parameters
         self.add_constraint(gen.qdamp, self.qdamp)

--- a/src/diffpy/srfit/pdf/pdfcontribution.py
+++ b/src/diffpy/srfit/pdf/pdfcontribution.py
@@ -84,7 +84,7 @@ class PDFContribution(FitContribution):
     def __init__(self, name):
         """Create the PDFContribution.
 
-        Attributes
+        Parameters
         ----------
         name
             The name of the contribution.
@@ -111,7 +111,7 @@ class PDFContribution(FitContribution):
         This uses the PDFParser to load the data and then passes it to the
         built-in profile with load_parsed_data.
 
-        Attributes
+        Parameters
         ----------
         data
             An open file-like object, name of a file that contains data
@@ -180,7 +180,7 @@ class PDFContribution(FitContribution):
     def addStructure(self, name, stru, periodic=True):
         """Add a phase that goes into the PDF calculation.
 
-        Attributes
+        Parameters
         ----------
         name
             A name to give the generator that will manage the PDF
@@ -224,7 +224,7 @@ class PDFContribution(FitContribution):
     def addPhase(self, name, parset, periodic=True):
         """Add a phase that goes into the PDF calculation.
 
-        Attributes
+        Parameters
         ----------
         name
             A name to give the generator that will manage the PDF
@@ -307,7 +307,7 @@ class PDFContribution(FitContribution):
     def setScatteringType(self, type="X"):
         """Set the scattering type.
 
-        Attributes
+        Parameters
         ----------
         type
             "X" for x-ray or "N" for neutron

--- a/src/diffpy/srfit/pdf/pdfparser.py
+++ b/src/diffpy/srfit/pdf/pdfparser.py
@@ -34,8 +34,6 @@ class PDFParser(ProfileParser):
     """Class for holding a diffraction pattern.
 
     Attributes
-
-    Attributes
     ----------
     _format
         Name of the data format that this parses (string, default

--- a/src/diffpy/srfit/sas/prcalculator.py
+++ b/src/diffpy/srfit/sas/prcalculator.py
@@ -66,7 +66,7 @@ class PrCalculator(Calculator):
     def __init__(self, name):
         """Initialize the generator.
 
-        Attributes
+        Parameters
         ----------
         name
             A name for the PrCalculator

--- a/src/diffpy/srfit/sas/sasgenerator.py
+++ b/src/diffpy/srfit/sas/sasgenerator.py
@@ -43,7 +43,7 @@ class SASGenerator(ProfileGenerator):
     def __init__(self, name, model):
         """Initialize the generator.
 
-        Attributes
+        Parameters
         ----------
         name
             A name for the SASGenerator

--- a/src/diffpy/srfit/sas/sasimport.py
+++ b/src/diffpy/srfit/sas/sasimport.py
@@ -18,7 +18,7 @@
 def sasimport(modname):
     """Import specified module from the SasView sas package.
 
-    Attributes
+    Parameters
     ----------
     modname
         absolute module name contained in the sas package.

--- a/src/diffpy/srfit/sas/sasparameter.py
+++ b/src/diffpy/srfit/sas/sasparameter.py
@@ -52,7 +52,7 @@ class SASParameter(Parameter):
     def __init__(self, name, model, parname=None):
         """Create the Parameter.
 
-        Attributes
+        Parameters
         ----------
         name
             Name of the Parameter

--- a/src/diffpy/srfit/sas/sasparser.py
+++ b/src/diffpy/srfit/sas/sasparser.py
@@ -31,8 +31,6 @@ class SASParser(ProfileParser):
     is held in the metadata under the name "datainfo".
 
     Attributes
-
-    Attributes
     ----------
     _format
         Name of the data format that this parses (string, default

--- a/src/diffpy/srfit/sas/sasprofile.py
+++ b/src/diffpy/srfit/sas/sasprofile.py
@@ -31,8 +31,6 @@ class SASProfile(Profile):
     object.
 
     Attributes
-
-    Attributes
     ----------
     _xobs
         A numpy array of the observed independent variable (default
@@ -78,7 +76,7 @@ class SASProfile(Profile):
     def __init__(self, datainfo):
         """Initialize the attributes.
 
-        Attributes
+        Parameters
         ----------
         datainfo
             The DataInfo object this wraps.

--- a/src/diffpy/srfit/structure/__init__.py
+++ b/src/diffpy/srfit/structure/__init__.py
@@ -25,7 +25,7 @@ def struToParameterSet(name, stru):
     This returns a ParameterSet adapted for the structure depending on its
     type.
 
-    Attributes
+    Parameters
     ----------
     stru
         a structure object known by this module

--- a/src/diffpy/srfit/structure/bvsrestraint.py
+++ b/src/diffpy/srfit/structure/bvsrestraint.py
@@ -47,7 +47,7 @@ class BVSRestraint(Restraint):
     def __init__(self, parset, sig=1, scaled=False):
         """Initialize the Restraint.
 
-        Attributes
+        Parameters
         ----------
         parset
             SrRealParSet that creates this BVSRestraint.
@@ -69,7 +69,7 @@ class BVSRestraint(Restraint):
     def penalty(self, w=1.0):
         """Calculate the penalty of the restraint.
 
-        Attributes
+        Parameters
         ----------
         w
             The point-average chi^2 which is optionally used to scale the

--- a/src/diffpy/srfit/structure/cctbxparset.py
+++ b/src/diffpy/srfit/structure/cctbxparset.py
@@ -56,7 +56,7 @@ class CCTBXScattererParSet(ParameterSet):
     def __init__(self, name, strups, idx):
         """Initialize.
 
-        Attributes
+        Parameters
         ----------
         name
             The name of this scatterer.
@@ -153,7 +153,7 @@ class CCTBXUnitCellParSet(ParameterSet):
     def __init__(self, strups):
         """Initialize.
 
-        Attributes
+        Parameters
         ----------
         strups
             The CCTBXCrystalParSet that contains the cctbx structure
@@ -228,7 +228,7 @@ class CCTBXCrystalParSet(BaseStructureParSet):
     def __init__(self, name, stru):
         """Initialize.
 
-        Attributes
+        Parameters
         ----------
         name
             A name for this

--- a/src/diffpy/srfit/structure/diffpyparset.py
+++ b/src/diffpy/srfit/structure/diffpyparset.py
@@ -91,7 +91,7 @@ class DiffpyAtomParSet(ParameterSet):
     def __init__(self, name, atom):
         """Initialize.
 
-        Attributes
+        Parameters
         ----------
         atom
             A diffpy.structure.Atom instance
@@ -205,7 +205,7 @@ class DiffpyLatticeParSet(ParameterSet):
     def __init__(self, lattice):
         """Initialize.
 
-        Attributes
+        Parameters
         ----------
         lattice
             A diffpy.structure.Lattice instance
@@ -275,7 +275,7 @@ class DiffpyStructureParSet(SrRealParSet):
     def __init__(self, name, stru):
         """Initialize.
 
-        Attributes
+        Parameters
         ----------
         name
             A name for the structure

--- a/src/diffpy/srfit/structure/objcrystparset.py
+++ b/src/diffpy/srfit/structure/objcrystparset.py
@@ -114,7 +114,7 @@ class ObjCrystScattererParSet(ParameterSet):
     def __init__(self, name, scat, parent):
         """Initialize.
 
-        Attributes
+        Parameters
         ----------
         name
             The name of the scatterer
@@ -176,7 +176,7 @@ class ObjCrystAtomParSet(ObjCrystScattererParSet):
     def __init__(self, name, atom, parent):
         """Initialize.
 
-        Attributes
+        Parameters
         ----------
         name
             The name of the scatterer
@@ -252,7 +252,7 @@ class ObjCrystMoleculeParSet(ObjCrystScattererParSet):
     def __init__(self, name, molecule, parent=None):
         """Initialize.
 
-        Attributes
+        Parameters
         ----------
         name
             The name of the scatterer
@@ -433,7 +433,7 @@ class ObjCrystMoleculeParSet(ObjCrystScattererParSet):
         This creates an instance of ObjCrystBondLengthRestraint and adds it to
         the ObjCrystMoleculeParSet.
 
-        Attributes
+        Parameters
         ----------
         atom1
             First atom (ObjCrystMolAtomParSet) in the bond
@@ -471,7 +471,7 @@ class ObjCrystMoleculeParSet(ObjCrystScattererParSet):
         This creates an instance of ObjCrystBondLengthRestraint and adds it to
         the ObjCrystMoleculeParSet.
 
-        Attributes
+        Parameters
         ----------
         par
             A ObjCrystBondLengthParameter (see addBondLengthParameter)
@@ -504,7 +504,7 @@ class ObjCrystMoleculeParSet(ObjCrystScattererParSet):
         This creates an instance of ObjCrystBondAngleRestraint and adds it to
         the ObjCrystMoleculeParSet.
 
-        Attributes
+        Parameters
         ----------
         atom1
             First atom (ObjCrystMolAtomParSet) in the bond angle
@@ -545,7 +545,7 @@ class ObjCrystMoleculeParSet(ObjCrystScattererParSet):
         This creates an instance of ObjCrystBondAngleRestraint and adds it to
         the ObjCrystMoleculeParSet.
 
-        Attributes
+        Parameters
         ----------
         par
             A ObjCrystBondAngleParameter (see addBondAngleParameter)
@@ -578,7 +578,7 @@ class ObjCrystMoleculeParSet(ObjCrystScattererParSet):
         This creates an instance of ObjCrystDihedralAngleRestraint and adds it
         to the ObjCrystMoleculeParSet.
 
-        Attributes
+        Parameters
         ----------
         atom1
             First atom (ObjCrystMolAtomParSet) in the angle
@@ -620,7 +620,7 @@ class ObjCrystMoleculeParSet(ObjCrystScattererParSet):
         This creates an instance of ObjCrystDihedralAngleRestraint and adds it
         to the ObjCrystMoleculeParSet.
 
-        Attributes
+        Parameters
         ----------
         par
             A ObjCrystDihedralAngleParameter (see
@@ -661,7 +661,7 @@ class ObjCrystMoleculeParSet(ObjCrystScattererParSet):
         This creates a ObjCrystBondLengthParameter to the
         ObjCrystMoleculeParSet that can be adjusted during the fit.
 
-        Attributes
+        Parameters
         ----------
         name
             The name of the ObjCrystBondLengthParameter
@@ -696,7 +696,7 @@ class ObjCrystMoleculeParSet(ObjCrystScattererParSet):
         This creates a ObjCrystBondAngleParameter to the ObjCrystMoleculeParSet
         that can be adjusted during the fit.
 
-        Attributes
+        Parameters
         ----------
         name
             The name of the ObjCrystBondAngleParameter
@@ -736,7 +736,7 @@ class ObjCrystMoleculeParSet(ObjCrystScattererParSet):
         This creates a ObjCrystDihedralAngleParameter to the
         ObjCrystMoleculeParSet that can be adjusted during the fit.
 
-        Attributes
+        Parameters
         ----------
         name
             The name of the ObjCrystDihedralAngleParameter.
@@ -809,7 +809,7 @@ class ObjCrystMolAtomParSet(ObjCrystScattererParSet):
     def __init__(self, name, scat, parent):
         """Initialize.
 
-        Attributes
+        Parameters
         ----------
         name
             The name of the scatterer
@@ -881,7 +881,7 @@ class ObjCrystMoleculeRestraint(object):
     def __init__(self, res, scaled=False):
         """Create a Restraint-like from a pyobjcryst Molecule restraint.
 
-        Attributes
+        Parameters
         ----------
         res
             The pyobjcryst Molecule restraint.
@@ -897,7 +897,7 @@ class ObjCrystMoleculeRestraint(object):
     def penalty(self, w=1.0):
         """Calculate the penalty of the restraint.
 
-        Attributes
+        Parameters
         ----------
         w
             The point-average chi^2 which is optionally used to scale the
@@ -938,7 +938,7 @@ class ObjCrystBondLengthRestraint(ObjCrystMoleculeRestraint):
     def __init__(self, atom1, atom2, length, sigma, delta, scaled=False):
         """Create a bond length restraint.
 
-        Attributes
+        Parameters
         ----------
         atom1
             First atom (ObjCrystMolAtomParSet) in the bond
@@ -1010,7 +1010,7 @@ class ObjCrystBondAngleRestraint(ObjCrystMoleculeRestraint):
     def __init__(self, atom1, atom2, atom3, angle, sigma, delta, scaled=False):
         """Create a bond angle restraint.
 
-        Attributes
+        Parameters
         ----------
         atom1
             First atom (ObjCrystMolAtomParSet) in the bond angle
@@ -1092,7 +1092,7 @@ class ObjCrystDihedralAngleRestraint(ObjCrystMoleculeRestraint):
     ):
         """Create a dihedral angle restraint.
 
-        Attributes
+        Parameters
         ----------
         atom1
             First atom (ObjCrystMolAtomParSet) in the angle
@@ -1168,7 +1168,7 @@ class StretchModeParameter(Parameter):
     def __init__(self, name, value=None, const=False):
         """Initialization.
 
-        Attributes
+        Parameters
         ----------
         name
             The name of this Parameter (must be a valid attribute
@@ -1314,7 +1314,7 @@ class ObjCrystBondLengthParameter(StretchModeParameter):
     def __init__(self, name, atom1, atom2, value=None, const=False, mode=None):
         """Create a ObjCrystBondLengthParameter.
 
-        Attributes
+        Parameters
         ----------
         name
             The name of the ObjCrystBondLengthParameter
@@ -1368,7 +1368,7 @@ class ObjCrystBondLengthParameter(StretchModeParameter):
         This sets the underlying ObjCrystMolAtomParSet positions
         constant as well.
 
-        Attributes
+        Parameters
         ----------
         is_constant
             Flag indicating if the Parameter is constant (default
@@ -1472,7 +1472,7 @@ class ObjCrystBondAngleParameter(StretchModeParameter):
     ):
         """Create a ObjCrystBondAngleParameter.
 
-        Attributes
+        Parameters
         ----------
         name
             The name of the ObjCrystBondAngleParameter.
@@ -1531,7 +1531,7 @@ class ObjCrystBondAngleParameter(StretchModeParameter):
         This sets the underlying ObjCrystMolAtomParSet positions
         constant as well.
 
-        Attributes
+        Parameters
         ----------
         is_constant
             Flag indicating if the Parameter is constant (default
@@ -1649,7 +1649,7 @@ class ObjCrystDihedralAngleParameter(StretchModeParameter):
     ):
         """Create a ObjCrystDihedralAngleParameter.
 
-        Attributes
+        Parameters
         ----------
         name
             The name of the ObjCrystDihedralAngleParameter
@@ -1712,7 +1712,7 @@ class ObjCrystDihedralAngleParameter(StretchModeParameter):
 
         This sets the underlying ObjCrystMolAtomParSet positions const as well.
 
-        Attributes
+        Parameters
         ----------
         is_constant
             Flag indicating if the Parameter is constant (default
@@ -1806,7 +1806,7 @@ class ObjCrystCrystalParSet(SrRealParSet):
     def __init__(self, name, cryst):
         """Initialize.
 
-        Attributes
+        Parameters
         ----------
         name
             A name for this ParameterSet
@@ -1881,7 +1881,7 @@ class ObjCrystCrystalParSet(SrRealParSet):
     def _create_space_group(sgobjcryst):
         """Create a diffpy.structure SpaceGroup object from pyobjcryst.
 
-        Attributes
+        Parameters
         ----------
         sgobjcryst
             A pyobjcryst.spacegroup.SpaceGroup instance.

--- a/src/diffpy/srfit/structure/objcrystparset.py
+++ b/src/diffpy/srfit/structure/objcrystparset.py
@@ -56,6 +56,37 @@ from diffpy.srfit.fitbase.parameter import (
 )
 from diffpy.srfit.fitbase.parameterset import ParameterSet
 from diffpy.srfit.structure.srrealparset import SrRealParSet
+from diffpy.utils._deprecator import build_deprecation_message, deprecated
+
+removal_version = "4.0.0"
+bl_base = "diffpy.srfit.structure.objcrystparset.ObjCrystBondLengthParameter"
+
+bl_setConst_dep_msg = build_deprecation_message(
+    bl_base,
+    "setConst",
+    "set_constant",
+    removal_version,
+)
+
+ba_base = "diffpy.srfit.structure.objcrystparset.ObjCrystBondAngleParameter"
+
+ba_setConst_dep_msg = build_deprecation_message(
+    ba_base,
+    "setConst",
+    "set_constant",
+    removal_version,
+)
+
+da_base = (
+    "diffpy.srfit.structure.objcrystparset.ObjCrystDihedralAngleParameter"
+)
+
+da_setConst_dep_msg = build_deprecation_message(
+    da_base,
+    "setConst",
+    "set_constant",
+    removal_version,
+)
 
 
 class ObjCrystScattererParSet(ParameterSet):
@@ -1327,31 +1358,49 @@ class ObjCrystBondLengthParameter(StretchModeParameter):
         if value is None:
             value = GetBondLength(atom1.scat, atom2.scat)
         StretchModeParameter.__init__(self, name, value, const)
-        self.setConst(const)
+        self.set_constant(const)
 
         return
 
-    def setConst(self, const=True, value=None):
+    def set_constant(self, is_constant=True, value=None):
         """Toggle the Parameter as constant.
 
-        This sets the underlying ObjCrystMolAtomParSet positions const as well.
+        This sets the underlying ObjCrystMolAtomParSet positions
+        constant as well.
 
         Attributes
         ----------
-        const
+        is_constant
             Flag indicating if the Parameter is constant (default
             True).
         value
             An optional value for the Parameter (default None). If this
             is not None, then the Parameter will get a new value,
             constant or otherwise.
+
+        Return
+        ------
+        self
+            Returns self so that mutators can be chained.
         """
-        StretchModeParameter.setConst(self, const, value)
+        StretchModeParameter.set_constant(self, is_constant, value)
 
         for a in [self.atom1, self.atom2]:
-            a.x.setConst(const)
-            a.y.setConst(const)
-            a.z.setConst(const)
+            a.x.set_constant(is_constant)
+            a.y.set_constant(is_constant)
+            a.z.set_constant(is_constant)
+        return self
+
+    @deprecated(bl_setConst_dep_msg)
+    def setConst(self, const=True, value=None):
+        """This function has been deprecated and will be removed in version
+        4.0.0.
+
+        Please use
+        diffpy.srfit.structure.objcryst.ObjCrystBondLengthParameter.set_constant
+        instead.
+        """
+        self.set_constant(const, value)
         return self
 
     def getValue(self):
@@ -1472,30 +1521,48 @@ class ObjCrystBondAngleParameter(StretchModeParameter):
         if value is None:
             value = GetBondAngle(atom1.scat, atom2.scat, atom3.scat)
         StretchModeParameter.__init__(self, name, value, const)
-        self.setConst(const)
+        self.set_constant(const)
 
         return
 
-    def setConst(self, const=True, value=None):
+    def set_constant(self, is_constant=True, value=None):
         """Toggle the Parameter as constant.
 
-        This sets the underlying ObjCrystMolAtomParSet positions const as well.
+        This sets the underlying ObjCrystMolAtomParSet positions
+        constant as well.
 
         Attributes
         ----------
-        const
+        is_constant
             Flag indicating if the Parameter is constant (default
             True).
         value
             An optional value for the Parameter (default None). If this
             is not None, then the Parameter will get a new value,
             constant or otherwise.
+
+        Return
+        ------
+        self
+            Returns self so that mutators can be chained.
         """
-        StretchModeParameter.setConst(self, const, value)
+        StretchModeParameter.set_constant(self, is_constant, value)
         for a in [self.atom1, self.atom2, self.atom3]:
-            a.x.setConst(const)
-            a.y.setConst(const)
-            a.z.setConst(const)
+            a.x.set_constant(is_constant)
+            a.y.set_constant(is_constant)
+            a.z.set_constant(is_constant)
+        return self
+
+    @deprecated(ba_setConst_dep_msg)
+    def setConst(self, const=True, value=None):
+        """This function has been deprecated and will be removed in
+        version 4.0.0.
+
+        Please use
+        diffpy.srfit.structure.objcryst.ObjCrystBondAngleParameter.set_constant
+        instead.
+        """
+        self.set_constant(const, value)
         return self
 
     def getValue(self):
@@ -1636,30 +1703,47 @@ class ObjCrystDihedralAngleParameter(StretchModeParameter):
                 atom1.scat, atom2.scat, atom3.scat, atom4.scat
             )
         StretchModeParameter.__init__(self, name, value, const)
-        self.setConst(const)
+        self.set_constant(const)
 
         return
 
-    def setConst(self, const=True, value=None):
+    def set_constant(self, is_constant=True, value=None):
         """Toggle the Parameter as constant.
 
         This sets the underlying ObjCrystMolAtomParSet positions const as well.
 
         Attributes
         ----------
-        const
+        is_constant
             Flag indicating if the Parameter is constant (default
             True).
         value
             An optional value for the Parameter (default None). If this
             is not None, then the Parameter will get a new value,
             constant or otherwise.
+
+        Return
+        ------
+        self
+            Returns self so that mutators can be chained.
         """
-        StretchModeParameter.setConst(self, const, value)
+        StretchModeParameter.set_constant(self, is_constant, value)
         for a in [self.atom1, self.atom2, self.atom3, self.atom4]:
-            a.x.setConst(const)
-            a.y.setConst(const)
-            a.z.setConst(const)
+            a.x.set_constant(is_constant)
+            a.y.set_constant(is_constant)
+            a.z.set_constant(is_constant)
+        return self
+
+    @deprecated(da_setConst_dep_msg)
+    def setConst(self, const=True, value=None):
+        """This function has been deprecated and will be removed in
+        version 4.0.0.
+
+        Please use
+        diffpy.srfit.structure.objcryst.ObjCrystDihedralAngleParameter.set_constant
+        instead.
+        """
+        self.set_constant(const, value)
         return self
 
     def getValue(self):

--- a/src/diffpy/srfit/structure/sgconstraints.py
+++ b/src/diffpy/srfit/structure/sgconstraints.py
@@ -392,7 +392,7 @@ class SpaceGroupParameters(BaseSpaceGroupParameters):
             for par in [scatterer.x, scatterer.y, scatterer.z]:
                 if scatterer.is_constrained(par):
                     scatterer.remove_constraint(par)
-                par.setConst(False)
+                par.set_constant(False)
 
         # Clear the lattice
         if self.constrainlat:
@@ -409,7 +409,7 @@ class SpaceGroupParameters(BaseSpaceGroupParameters):
             for par in latpars:
                 if lattice.is_constrained(par):
                     lattice.remove_constraint(par)
-                par.setConst(False)
+                par.set_constant(False)
 
         # Clear ADPs
         if self.constrainadps:
@@ -419,14 +419,14 @@ class SpaceGroupParameters(BaseSpaceGroupParameters):
                     if par is not None:
                         if scatterer.is_constrained(par):
                             scatterer.remove_constraint(par)
-                        par.setConst(False)
+                        par.set_constant(False)
 
                 for pname in adpsymbols:
                     par = scatterer.get(pname)
                     if par is not None:
                         if scatterer.is_constrained(par):
                             scatterer.remove_constraint(par)
-                        par.setConst(False)
+                        par.set_constant(False)
 
         return
 
@@ -652,14 +652,14 @@ def _constrain_monoclinic(lattice):
     if lattice.angunits == "rad":
         afactor = deg2rad
     ang90 = 90.0 * afactor
-    lattice.alpha.setConst(True, ang90)
+    lattice.alpha.set_constant(True, ang90)
     beta = lattice.beta.getValue()
     gamma = lattice.gamma.getValue()
 
     if ang90 != beta and ang90 == gamma:
-        lattice.gamma.setConst(True, ang90)
+        lattice.gamma.set_constant(True, ang90)
     else:
-        lattice.beta.setConst(True, ang90)
+        lattice.beta.set_constant(True, ang90)
     return
 
 
@@ -672,9 +672,9 @@ def _constrain_orthorhombic(lattice):
     if lattice.angunits == "rad":
         afactor = deg2rad
     ang90 = 90.0 * afactor
-    lattice.alpha.setConst(True, ang90)
-    lattice.beta.setConst(True, ang90)
-    lattice.gamma.setConst(True, ang90)
+    lattice.alpha.set_constant(True, ang90)
+    lattice.beta.set_constant(True, ang90)
+    lattice.gamma.set_constant(True, ang90)
     return
 
 
@@ -688,9 +688,9 @@ def _constrain_tetragonal(lattice):
     if lattice.angunits == "rad":
         afactor = deg2rad
     ang90 = 90.0 * afactor
-    lattice.alpha.setConst(True, ang90)
-    lattice.beta.setConst(True, ang90)
-    lattice.gamma.setConst(True, ang90)
+    lattice.alpha.set_constant(True, ang90)
+    lattice.beta.set_constant(True, ang90)
+    lattice.gamma.set_constant(True, ang90)
     lattice.add_constraint(lattice.b, lattice.a)
     return
 
@@ -709,9 +709,9 @@ def _constrain_trigonal(lattice):
     ang120 = 120.0 * afactor
     if lattice.gamma.getValue() == ang120:
         lattice.add_constraint(lattice.b, lattice.a)
-        lattice.alpha.setConst(True, ang90)
-        lattice.beta.setConst(True, ang90)
-        lattice.gamma.setConst(True, ang120)
+        lattice.alpha.set_constant(True, ang90)
+        lattice.beta.set_constant(True, ang90)
+        lattice.gamma.set_constant(True, ang120)
     else:
         lattice.add_constraint(lattice.b, lattice.a)
         lattice.add_constraint(lattice.c, lattice.a)
@@ -732,9 +732,9 @@ def _constrain_hexagonal(lattice):
     ang90 = 90.0 * afactor
     ang120 = 120.0 * afactor
     lattice.add_constraint(lattice.b, lattice.a)
-    lattice.alpha.setConst(True, ang90)
-    lattice.beta.setConst(True, ang90)
-    lattice.gamma.setConst(True, ang120)
+    lattice.alpha.set_constant(True, ang90)
+    lattice.beta.set_constant(True, ang90)
+    lattice.gamma.set_constant(True, ang120)
     return
 
 
@@ -750,9 +750,9 @@ def _constrain_cubic(lattice):
     ang90 = 90.0 * afactor
     lattice.add_constraint(lattice.b, lattice.a)
     lattice.add_constraint(lattice.c, lattice.a)
-    lattice.alpha.setConst(True, ang90)
-    lattice.beta.setConst(True, ang90)
-    lattice.gamma.setConst(True, ang90)
+    lattice.alpha.set_constant(True, ang90)
+    lattice.beta.set_constant(True, ang90)
+    lattice.gamma.set_constant(True, ang90)
     return
 
 
@@ -805,7 +805,7 @@ def _makeconstraint(parname, formula, scatterer, idx, ns={}):
     # Check to see if it is a constant
     fval = _get_float(formula)
     if fval is not None:
-        par.setConst()
+        par.set_constant()
         return
 
     # If we got here, then we have a constraint equation

--- a/src/diffpy/srfit/structure/sgconstraints.py
+++ b/src/diffpy/srfit/structure/sgconstraints.py
@@ -190,7 +190,7 @@ class BaseSpaceGroupParameters(RecipeContainer):
     def addParameter(self, par, check=True):
         """Store a Parameter.
 
-        Attributes
+        Parameters
         ----------
         par
             The Parameter to be stored.
@@ -470,7 +470,7 @@ class SpaceGroupParameters(BaseSpaceGroupParameters):
     def _constrain_xyzs(self, positions):
         """Constrain the positions.
 
-        Attributes
+        Parameters
         ----------
         positions
             The coordinates of the scatterers.
@@ -513,7 +513,7 @@ class SpaceGroupParameters(BaseSpaceGroupParameters):
     def _constrain_adps(self, positions):
         """Constrain the ADPs.
 
-        Attributes
+        Parameters
         ----------
         positions
             The coordinates of the scatterers.
@@ -618,7 +618,7 @@ class SpaceGroupParameters(BaseSpaceGroupParameters):
     def __add_par(self, parname, par):
         """Constrain a parameter via proxy with a specified name.
 
-        Attributes
+        Parameters
         ----------
         par
             Parameter to constrain
@@ -772,7 +772,7 @@ _constraintMap = {
 def _makeconstraint(parname, formula, scatterer, idx, ns={}):
     """Constrain a parameter according to a formula.
 
-    Attributes
+    Parameters
     ----------
     parname
         Name of parameter

--- a/src/diffpy/srfit/structure/srrealparset.py
+++ b/src/diffpy/srfit/structure/srrealparset.py
@@ -52,7 +52,7 @@ class SrRealParSet(BaseStructureParSet):
         this is also scaled by the current point-averaged chi^2 value so the
         restraint is roughly equally weighted in the fit.
 
-        Attributes
+        Parameters
         ----------
         sig
             The uncertainty on the BVS (default 1).

--- a/src/diffpy/srfit/util/inpututils.py
+++ b/src/diffpy/srfit/util/inpututils.py
@@ -26,7 +26,7 @@ def inputToString(input):
     This is useful when you want a method to accept a string, open file object
     or file name.
 
-    Attributes
+    Parameters
     ----------
     input
         An open file-like object, name of a file

--- a/src/diffpy/srfit/util/tagmanager.py
+++ b/src/diffpy/srfit/util/tagmanager.py
@@ -53,7 +53,7 @@ class TagManager(object):
 
         Tags are stored as strings.
 
-        Attributes
+        Parameters
         ----------
         obj
             Any hashable object to be untagged.
@@ -71,7 +71,7 @@ class TagManager(object):
     def untag(self, obj, *tags):
         """Remove tags from an object.
 
-        Attributes
+        Parameters
         ----------
         obj
             Any hashable object to be untagged.

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -46,7 +46,7 @@ class TestConstraint(unittest.TestCase):
         eq2 = get_equation_from_string("2*p2+1", factory)
         c2 = Constraint()
         self.assertRaises(ValueError, c2.constrain, p1, eq2)
-        p2.setConst()
+        p2.set_constant()
         eq3 = get_equation_from_string("p1", factory)
         self.assertRaises(ValueError, c2.constrain, p2, eq3)
 

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -16,6 +16,9 @@
 
 import unittest
 
+import numpy as np
+import pytest
+
 from diffpy.srfit.fitbase.parameter import (
     Parameter,
     ParameterAdapter,
@@ -119,6 +122,96 @@ class TestParameterAdapter(unittest.TestCase):
         self.assertEqual(par_l.getValue(), la.getValue())
 
         return
+
+
+@pytest.mark.parametrize(
+    "lower, upper, expected",
+    [
+        # User sets both lower and upper bounds explicitly.
+        (1, 10, [1, 10]),
+        # User sets only a lower bound.
+        (2, None, [2, np.inf]),
+        # User sets only an upper bound.
+        (None, 8, [-np.inf, 8]),
+        # User overwrites existing bounds.
+        (2, 6, [2, 6]),
+    ],
+)
+def test_bound_range(lower, upper, expected):
+    p = Parameter("a", value=5)
+    # If testing overwrite, pre-set bounds to see overwrite effect
+    if expected == [2, 6]:
+        p.bound_range(0, 10)
+    p.bound_range(lower_bound=lower, upper_bound=upper)
+    actual = p.bounds
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "lower, upper, expected",
+    [
+        # User sets both lower and upper bounds explicitly.
+        (1, 10, [1, 10]),
+        # User sets only a lower bound.
+        (2, None, [2, np.inf]),
+        # User sets only an upper bound.
+        (None, 8, [-np.inf, 8]),
+        # User overwrites existing bounds.
+        (2, 6, [2, 6]),
+    ],
+)
+def test_boundRange(lower, upper, expected):
+    p = Parameter("a", value=5)
+    # If testing overwrite, pre-set bounds to see overwrite effect
+    if expected == [2, 6]:
+        p.boundRange(0, 10)
+    p.boundRange(lower_bound=lower, upper_bound=upper)
+    actual = p.bounds
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "value, lower_radius, upper_radius, expected",
+    [
+        # Symmetric radius (upper_radius None, uses lower_radius)
+        (10, 2, None, [8, 12]),
+        # Asymmetric radius
+        (10, 3, 5, [7, 15]),
+        # Zero radius
+        (4, 0, None, [4, 4]),
+        # Current value updated before bounding
+        (20, 2, None, [18, 22]),
+    ],
+)
+def test_bound_window(value, lower_radius, upper_radius, expected):
+    p = Parameter("a", value=5)
+    if value != 5:
+        p.set_value(value)
+    p.bound_window(lower_radius=lower_radius, upper_radius=upper_radius)
+    actual = p.bounds
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "value, lower_radius, upper_radius, expected",
+    [
+        # Symmetric radius (upper_radius None, uses lower_radius)
+        (10, 2, None, [8, 12]),
+        # Asymmetric radius
+        (10, 3, 5, [7, 15]),
+        # Zero radius
+        (4, 0, None, [4, 4]),
+        # Current value updated before bounding
+        (20, 2, None, [18, 22]),
+    ],
+)
+def test_boundWindow(value, lower_radius, upper_radius, expected):
+    p = Parameter("a", value=5)
+    if value != 5:
+        p.set_value(value)
+    p.boundWindow(lr=lower_radius, ur=upper_radius)
+    actual = p.bounds
+    assert actual == expected
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In addition to method deprecation, I replaced `Attributes` with `Parameters` in function docstrings everywhere. Also, turned `processMetaData` into a private function.