### PR TITLE
fix: fix Qmax update after load new parsed data

### DIFF
--- a/news/fix-qmax-update.rst
+++ b/news/fix-qmax-update.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/fix-qmax-update.rst
+++ b/news/fix-qmax-update.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* <news item>
+* Fixed load new parsed data with updated `Qmax` attribute
 
 **Security:**
 

--- a/src/diffpy/srfit/fitbase/profilegenerator.py
+++ b/src/diffpy/srfit/fitbase/profilegenerator.py
@@ -163,15 +163,18 @@ class ProfileGenerator(Operator, ParameterSet):
             will store the calculated signal.
         """
         if self.profile is not None:
-            self.profile.removeObserver(self._flush)
+            self.profile.removeObserver(self._on_profile_changed)
 
         self.profile = profile
-        self.profile.addObserver(self._flush)
-        self._flush(other=(self,))
+        self.profile.addObserver(self._on_profile_changed)
+        self._on_profile_changed(other=(self,))
+        return
 
-        # Merge the profiles metadata with our own
-        self.meta.update(self.profile.meta)
-        self.processMetaData()
+    def _on_profile_changed(self, other=()):
+        if self.profile is not None:
+            self.meta.update(self.profile.meta)
+            self.processMetaData()
+        self._flush(other=other)
         return
 
     def processMetaData(self):

--- a/src/diffpy/srfit/fitbase/profilegenerator.py
+++ b/src/diffpy/srfit/fitbase/profilegenerator.py
@@ -163,14 +163,14 @@ class ProfileGenerator(Operator, ParameterSet):
             will store the calculated signal.
         """
         if self.profile is not None:
-            self.profile.removeObserver(self._on_profile_changed)
+            self.profile.removeObserver(self._on_profile_update)
 
         self.profile = profile
-        self.profile.addObserver(self._on_profile_changed)
-        self._on_profile_changed(other=(self,))
+        self.profile.addObserver(self._on_profile_update)
+        self._on_profile_update(other=(self,))
         return
 
-    def _on_profile_changed(self, other=()):
+    def _on_profile_update(self, other=()):
         if self.profile is not None:
             self.meta.update(self.profile.meta)
             self.processMetaData()


### PR DESCRIPTION
@sbillinge ready to review. Note that the logic here is pretty the same as before, but the difference is that in the process of loading the metadata, we need to update it right after we load it so that `Qmax` could be updated. And then we do the `self._flush` to dump other parameters into the `Profile`. Since we might need to use it internally multiple times, I made a private function for this. I also did a test on the local for what we can test here #59. Using the script that provided, I confirmed that `Qmax` is indeed updated when we `loadParsedData` again. 
Closes #59 
```
diffpy.srfit_env) huarundong@Stevens-MacBook-Pro-405 diffpy.srfit % python check_qmax_reload.py test_1.txt test_2.txt
/Users/huarundong/dbs/diffpy.srfit/check_qmax_reload.py:94: DeprecationWarning: 'diffpy.srfit.fitbase.FitContribution.setProfile' is deprecated and will be removed in version 4.0.0. Please use 'diffpy.srfit.fitbase.FitContribution.set_profile' instead.
  contribution.setProfile(profile, xname="r")

Initial generator Q_max from test_1.txt: 25.0

Metadata in new file suggests Q_max should be 40.0, q_max is now 40.0

These are equal

Now setting Qmax manually from the second file metadata...

Metadata in new file suggests Q_max should be 40.0, q_max is now 40.0

These are equal

Result: Qmax already updates on profile reload.
```