### PR TITLE
build: add diffpy.structure back to requirement

### DIFF
--- a/news/fix-test-package.rst
+++ b/news/fix-test-package.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added `diffpy.structure` back to the requirements and run the test
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -3,3 +3,4 @@ numpy
 scipy
 bg-mpl-stylesheets
 diffpy.utils
+diffpy.structure

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -3,3 +3,4 @@ numpy
 scipy
 bg-mpl-stylesheets
 diffpy.utils
+diffpy.structure

--- a/src/diffpy/__init__.py
+++ b/src/diffpy/__init__.py
@@ -13,3 +13,6 @@
 # See LICENSE.rst for license information.
 #
 ##############################################################################
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,11 +74,6 @@ def sas_available():
 
 
 @pytest.fixture(scope="session")
-def diffpy_structure_available():
-    return has_diffpy_structure()
-
-
-@pytest.fixture(scope="session")
 def diffpy_srreal_available():
     return has_diffpy_srreal()
 

--- a/tests/test_diffpyparset.py
+++ b/tests/test_diffpyparset.py
@@ -18,15 +18,12 @@ import pickle
 import unittest
 
 import numpy as np
-import pytest
 
 from diffpy.srfit.structure.diffpyparset import DiffpyStructureParSet
 
 
-def testDiffpyStructureParSet(diffpy_structure_available):
+def testDiffpyStructureParSet():
     """Test the structure conversion."""
-    if not diffpy_structure_available:
-        pytest.skip("diffpy.structure package not available")
     from diffpy.structure import Atom, Lattice, Structure
 
     a1 = Atom("Cu", xyz=np.array([0.0, 0.1, 0.2]), Uisoequiv=0.003)
@@ -103,10 +100,8 @@ def testDiffpyStructureParSet(diffpy_structure_available):
     return
 
 
-def test___repr__(diffpy_structure_available):
+def test___repr__():
     """Test representation of DiffpyStructureParSet objects."""
-    if not diffpy_structure_available:
-        pytest.skip("diffpy.structure package not available")
     from diffpy.structure import Atom, Lattice, Structure
 
     lat = Lattice(3, 3, 2, 90, 90, 90)
@@ -119,10 +114,8 @@ def test___repr__(diffpy_structure_available):
     return
 
 
-def test_pickling(diffpy_structure_available):
+def test_pickling():
     """Test pickling of DiffpyStructureParSet."""
-    if not diffpy_structure_available:
-        pytest.skip("diffpy.structure package not available")
     from diffpy.structure import Atom, Structure
 
     stru = Structure([Atom("C", [0, 0.2, 0.5])])

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -140,11 +140,7 @@ def testParser2(datafile):
     return
 
 
-def testGenerator(
-    diffpy_srreal_available, diffpy_structure_available, datafile
-):
-    if not diffpy_structure_available:
-        pytest.skip("diffpy.structure package not available")
+def testGenerator(diffpy_srreal_available, datafile):
     if not diffpy_srreal_available:
         pytest.skip("diffpy.srreal package not available")
 
@@ -200,7 +196,7 @@ def testGenerator(
     return
 
 
-def test_setQmin(diffpy_structure_available, diffpy_srreal_available):
+def test_setQmin(diffpy_srreal_available):
     """Verify qmin is propagated to the calculator object."""
     if not diffpy_srreal_available:
         pytest.skip("diffpy.srreal package not available")
@@ -214,10 +210,8 @@ def test_setQmin(diffpy_structure_available, diffpy_srreal_available):
     return
 
 
-def test_setQmax(diffpy_structure_available, diffpy_srreal_available):
+def test_setQmax(diffpy_srreal_available):
     """Check PDFContribution.setQmax()"""
-    if not diffpy_structure_available:
-        pytest.skip("diffpy.structure package not available")
     from diffpy.structure import Structure
 
     if not diffpy_srreal_available:
@@ -233,10 +227,8 @@ def test_setQmax(diffpy_structure_available, diffpy_srreal_available):
     return
 
 
-def test_getQmax(diffpy_structure_available, diffpy_srreal_available):
+def test_getQmax(diffpy_srreal_available):
     """Check PDFContribution.getQmax()"""
-    if not diffpy_structure_available:
-        pytest.skip("diffpy.structure package not available")
     from diffpy.structure import Structure
 
     if not diffpy_srreal_available:
@@ -260,12 +252,8 @@ def test_getQmax(diffpy_structure_available, diffpy_srreal_available):
     return
 
 
-def test_savetxt(
-    diffpy_structure_available, diffpy_srreal_available, datafile
-):
+def test_savetxt(diffpy_srreal_available, datafile):
     "check PDFContribution.savetxt()"
-    if not diffpy_structure_available:
-        pytest.skip("diffpy.structure package not available")
     from diffpy.structure import Structure
 
     if not diffpy_srreal_available:
@@ -286,12 +274,8 @@ def test_savetxt(
     return
 
 
-def test_pickling(
-    diffpy_structure_available, diffpy_srreal_available, datafile
-):
+def test_pickling(diffpy_srreal_available, datafile):
     "validate PDFContribution.residual() after pickling."
-    if not diffpy_structure_available:
-        pytest.skip("diffpy.structure package not available")
     from diffpy.structure import loadStructure
 
     if not diffpy_srreal_available:


### PR DESCRIPTION
@sbillinge ready to review. As now we have released the new version of `diffpy.structure`, we should add this back to the requirements and run the test on CI. This partially fixes #152 but we need to remove the skip for `diffpy.srreal` so that we could close this issue.