### PR TITLE
chore: deprecate scatterFactoringTableByType method

### DIFF
--- a/news/deprecate-scatterFactoringTableByType.rst
+++ b/news/deprecate-scatterFactoringTableByType.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added new api call for `scatteringfactortable` from `diffpy.srreal`
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* Removed the use of `scatterFactoringTableByType` method from `diffpy.srreal`
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -4,3 +4,4 @@ scipy
 bg-mpl-stylesheets
 diffpy.utils
 diffpy.structure
+diffpy.srreal

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,3 +4,4 @@ scipy
 bg-mpl-stylesheets
 diffpy.utils
 diffpy.structure
+diffpy.srreal

--- a/src/diffpy/srfit/pdf/basepdfgenerator.py
+++ b/src/diffpy/srfit/pdf/basepdfgenerator.py
@@ -26,6 +26,7 @@ from diffpy.srfit.exceptions import SrFitError
 from diffpy.srfit.fitbase import ProfileGenerator
 from diffpy.srfit.fitbase.parameter import ParameterAdapter
 from diffpy.srfit.structure import struToParameterSet
+from diffpy.srreal.srreal_ext import SFTNeutron
 
 # FIXME - Parameter creation will have to be smarter once deeper calculator
 # configuration is enabled.
@@ -190,7 +191,8 @@ class BasePDFGenerator(ProfileGenerator):
 
         Raises ValueError for unknown scattering type.
         """
-        self._calc.setScatteringFactorTableByType(stype)
+        self._calc.scatteringfactortable = SFTNeutron()
+        self._calc.scatteringfactortable.createByType(stype)
         # update the meta dictionary only if there was no exception
         self.meta["stype"] = self.getScatteringType()
         return

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -24,6 +24,7 @@ import pytest
 
 from diffpy.srfit.exceptions import SrFitError
 from diffpy.srfit.pdf import PDFContribution, PDFGenerator, PDFParser
+from diffpy.srreal.srreal_ext import SFTNeutron
 
 # ----------------------------------------------------------------------------
 
@@ -186,7 +187,8 @@ def testGenerator(diffpy_srreal_available, datafile):
     calc.rmin = r[0]
     calc.rmax = r[-1] + 0.5 * calc.rstep
     calc.qmax = qmax
-    calc.setScatteringFactorTableByType("N")
+    calc.scatteringfactortable = SFTNeutron()
+    calc.scatteringfactortable.createByType("N")
     calc.eval(stru)
     yref = calc.pdf
 


### PR DESCRIPTION
@sbillinge We need to keep this open for a while as right now we didn't list `diffpy.srreal` as a dependency. When we release the new version of `diffpy.srreal` we can add this back to our requirements and rerun the test. This closes #137 